### PR TITLE
[Cleanup] Refactor erc20 artifacts and amount handling

### DIFF
--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,41 @@
+import BigNumber from "bignumber.js";
+import { expect } from "chai";
+import { fromWei, toWei, TEN, ONE, ZERO } from "src/utils";
+
+// TODO - this is super ugly at the moment and is probably missing some stuff.
+describe("toWei()", () => {
+  it("decimals", () => {
+    expect(toWei("0.00000001", 0).eq(ZERO));
+    expect(toWei("0.1", 1).eq(ONE));
+    expect(toWei("0.0000000000000000001", 18).eq(ONE));
+  });
+  it("integers", () => {
+    expect(toWei(1, 0).eq(ONE));
+    expect(toWei(123, 1).eq(new BigNumber(1230)));
+    expect(toWei(1, 18).eq(new BigNumber(1000000000000000000)));
+  });
+  it("mixed", () => {
+    expect(toWei(1.234, 0).eq(ONE));
+    expect(toWei(1.234, 3).eq(new BigNumber(1234)));
+    expect(
+      toWei(1.00000000000000000001, 18).eq(new BigNumber(1000000000000000000))
+    );
+  });
+});
+
+describe("fromWei()", () => {
+  it("works as expected on legit input", () => {
+    const oneETH = TEN.pow(18);
+    expect(fromWei(oneETH, 0).toString()).to.be.equal("1000000000000000000");
+    expect(fromWei(oneETH, 9).toString()).to.be.equal((10 ** 9).toString());
+    expect(fromWei(oneETH, 18).toString()).to.be.equal("1");
+    expect(fromWei(oneETH, 19).toString()).to.be.equal("0.1");
+    expect(fromWei(oneETH, 20).toString()).to.be.equal("0.01");
+
+    expect(fromWei(oneETH, 0).toFixed()).to.be.equal("1000000000000000000");
+    expect(fromWei(oneETH, 9).toFixed()).to.be.equal((10 ** 9).toString());
+    expect(fromWei(oneETH, 18).toFixed()).to.be.equal("1");
+    expect(fromWei(oneETH, 19).toFixed()).to.be.equal("0.1");
+    expect(fromWei(oneETH, 20).toFixed()).to.be.equal("0.01");
+  });
+});

--- a/src/erc20.ts
+++ b/src/erc20.ts
@@ -1,0 +1,11 @@
+import { ethers } from "ethers";
+import IERC20 from "@openzeppelin/contracts/build/contracts/IERC20.json";
+
+export const erc20Interface = new ethers.utils.Interface(IERC20.abi);
+
+export function erc20Instance(
+  address: string,
+  provider: ethers.providers.Provider
+): ethers.Contract {
+  return new ethers.Contract(address, erc20Interface, provider);
+}

--- a/src/transfers.ts
+++ b/src/transfers.ts
@@ -1,50 +1,30 @@
 import { Transaction } from "@gnosis.pm/safe-apps-sdk";
 import { TokenMap } from "./hooks/tokenList";
-import BigNumber from "bignumber.js";
 import { Payment } from "./parser";
-import { ethers } from "ethers";
-import IERC20 from "@openzeppelin/contracts/build/contracts/IERC20.json";
-
-export const TEN = new BigNumber(10);
-
-// TODO - when token data is unknown need to get contract at address with web3Provider
-// const erc20 = new ethers.Contract(token.address, IERC20.abi, provider);
+import { toWei } from "./utils";
+import { erc20Interface } from "./erc20";
 
 export function buildTransfers(
   transferData: Payment[],
   tokenList: TokenMap
 ): Transaction[] {
-  const erc20 = new ethers.utils.Interface(IERC20.abi);
   const txList: Transaction[] = transferData.map((transfer, _) => {
     if (transfer.tokenAddress === null) {
       // Native asset transfer
       return {
         to: transfer.receiver,
-        value: transfer.amount.multipliedBy(TEN.pow(18)).toFixed(),
+        value: toWei(transfer.amount, 18).toFixed(),
         data: "0x",
       };
     } else {
       // ERC20 transfer
-      const exponent = new BigNumber(
-        TEN.pow(
-          tokenList.get(transfer.tokenAddress)?.decimals || transfer.decimals
-        )
-      );
-      let amountData = transfer.amount.multipliedBy(exponent);
-      if (amountData.decimalPlaces() > 0) {
-        // TODO - reinstate this warning by passing along with return content
-        // Return (Transaction[], Message)
-        // setLastError({
-        //   message:
-        //     "Precision too high. Some digits are ignored for row " + index,
-        // });
-        amountData = amountData.decimalPlaces(0, BigNumber.ROUND_DOWN);
-      }
-
+      const decimals =
+        tokenList.get(transfer.tokenAddress)?.decimals || transfer.decimals;
+      let amountData = toWei(transfer.amount, decimals);
       return {
         to: transfer.tokenAddress,
         value: "0",
-        data: erc20.encodeFunctionData("transfer", [
+        data: erc20Interface.encodeFunctionData("transfer", [
           transfer.receiver,
           amountData.toFixed(),
         ]),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,28 @@
+import BigNumber from "bignumber.js";
+
+export const ZERO = new BigNumber(0);
+export const ONE = new BigNumber(1);
+export const TWO = new BigNumber(2);
+export const TEN = new BigNumber(10);
+export const MAX_U256 = TWO.pow(255).minus(1);
+
+export function toWei(
+  amount: string | number | BigNumber,
+  decimals: number
+): BigNumber {
+  let res = TEN.pow(decimals).multipliedBy(amount);
+  if (res.decimalPlaces() > 0) {
+    // TODO - reinstate this warning by passing along with return content
+    // Return (Transaction[], Message)
+    // setLastError({
+    //   message:
+    //     "Precision too high. Some digits are ignored for row " + index,
+    // });
+    res = res.decimalPlaces(0, BigNumber.ROUND_DOWN);
+  }
+  return res;
+}
+
+export function fromWei(amount: BigNumber, decimals: number): BigNumber {
+  return amount.dividedBy(TEN.pow(decimals));
+}


### PR DESCRIPTION
1. New file erc20 which contains all the erc20 artifacts we will need.
2. Introduce utils with to and from Wei for number conversions
3. Refactor transfer tests to remove hardcoded bytes as expected values.

Test Plan:

Still works with our mainnet regression test file [Verified] 

