### PR TITLE
add drag and drop file-upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+#vscode environment
+/.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "typescript.tsdk": "node_modules/typescript/lib"
-}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-app-rewired": "^2.1.6",
     "react-csv-reader": "^3.1.1",
     "react-dom": "^16.13.1",
+    "react-dropzone": "^11.3.2",
     "react-scripts": "3.4.3",
     "react-svg": "^11.1.4",
     "styled-components": "^5.1.1",

--- a/src/components/CSVEditor.tsx
+++ b/src/components/CSVEditor.tsx
@@ -13,7 +13,7 @@ export type CSVEditorProps = {
   csvText: string;
 };
 
-export const CSVEditor = (props: CSVEditorProps) => {
+export const CSVEditor = (props: CSVEditorProps): JSX.Element => {
   const { codeWarnings } = useContext(MessageContext);
   return (
     <EditorWrapper>

--- a/src/components/CSVEditor.tsx
+++ b/src/components/CSVEditor.tsx
@@ -1,0 +1,52 @@
+import AceEditor, { IMarker } from "react-ace";
+import "ace-builds/src-noconflict/theme-tomorrow";
+import "ace-builds/src-noconflict/mode-text";
+import styled from "styled-components";
+import React, { useContext } from "react";
+import { MessageContext } from "src/contexts/MessageContextProvider";
+
+const EditorWrapper = styled.div``;
+
+export type CSVEditorProps = {
+  onChange: (csvContent: string) => void;
+  csvText: string;
+};
+
+export const CSVEditor = (props: CSVEditorProps) => {
+  const { codeWarnings } = useContext(MessageContext);
+  return (
+    <EditorWrapper>
+      <AceEditor
+        onChange={(newCode) => props.onChange(newCode)}
+        value={props.csvText}
+        theme="tomorrow"
+        width={"700px"}
+        mode={"text"}
+        minLines={6}
+        maxLines={32}
+        setOptions={{
+          firstLineNumber: 0,
+        }}
+        debounceChangePeriod={200}
+        showPrintMargin={false}
+        style={{
+          borderWidth: 1,
+          borderColor: "rgba(0, 0, 0, 0.23)",
+          borderRadius: "4px",
+          borderStyle: "solid",
+          boxShadow: "rgba(40, 54, 61, 0.12) 1px 2px 4px 0px",
+        }}
+        markers={codeWarnings.map(
+          (warning): IMarker => ({
+            startRow: warning.lineNo,
+            endRow: warning.lineNo,
+            className: "error-marker",
+            type: "fullLine",
+            startCol: 0,
+            endCol: 30,
+          })
+        )}
+      />
+    </EditorWrapper>
+  );
+};

--- a/src/components/CSVForm.tsx
+++ b/src/components/CSVForm.tsx
@@ -9,11 +9,9 @@ import {
 } from "@gnosis.pm/safe-react-components";
 import { TokenMap } from "src/hooks/tokenList";
 import { Payment } from "src/parser";
-import AceEditor, { IMarker } from "react-ace";
-import "ace-builds/src-noconflict/theme-tomorrow";
-import "ace-builds/src-noconflict/mode-text";
 import { MessageContext } from "src/contexts/MessageContextProvider";
 import { CSVUpload } from "./CSVUpload";
+import { CSVEditor } from "./CSVEditor";
 
 const Form = styled.div`
   flex: 1;
@@ -22,8 +20,6 @@ const Form = styled.div`
   justify-content: space-around;
   gap: 8px;
 `;
-
-const EditorWrapper = styled.div``;
 
 export interface CSVFormProps {
   onChange: (transactionCSV: string) => void;
@@ -64,39 +60,8 @@ export const CSVForm = (props: CSVFormProps) => {
           Upload, edit or paste your transfer CSV. <br />
           (token_address,receiver,amount,decimals)
         </Text>
-        <EditorWrapper>
-          <AceEditor
-            onChange={(newCode) => props.onChange(newCode)}
-            value={props.csvText}
-            theme="tomorrow"
-            width={"700px"}
-            mode={"text"}
-            minLines={6}
-            maxLines={32}
-            setOptions={{
-              firstLineNumber: 0,
-            }}
-            debounceChangePeriod={200}
-            showPrintMargin={false}
-            style={{
-              borderWidth: 1,
-              borderColor: "rgba(0, 0, 0, 0.23)",
-              borderRadius: "4px",
-              borderStyle: "solid",
-              boxShadow: "rgba(40, 54, 61, 0.12) 1px 2px 4px 0px",
-            }}
-            markers={codeWarnings.map(
-              (warning): IMarker => ({
-                startRow: warning.lineNo,
-                endRow: warning.lineNo,
-                className: "error-marker",
-                type: "fullLine",
-                startCol: 0,
-                endCol: 30,
-              })
-            )}
-          />
-        </EditorWrapper>
+
+        <CSVEditor csvText={props.csvText} onChange={props.onChange} />
 
         <CSVUpload onChange={props.onChange} />
 

--- a/src/components/CSVForm.tsx
+++ b/src/components/CSVForm.tsx
@@ -4,7 +4,6 @@ import {
   Card,
   Text,
   Button,
-  Link,
   Table,
   Loader,
 } from "@gnosis.pm/safe-react-components";
@@ -14,6 +13,7 @@ import AceEditor, { IMarker } from "react-ace";
 import "ace-builds/src-noconflict/theme-tomorrow";
 import "ace-builds/src-noconflict/mode-text";
 import { MessageContext } from "src/contexts/MessageContextProvider";
+import { CSVUpload } from "./CSVUpload";
 
 const Form = styled.div`
   flex: 1;
@@ -37,6 +37,7 @@ export interface CSVFormProps {
 
 export const CSVForm = (props: CSVFormProps) => {
   const { codeWarnings } = useContext(MessageContext);
+
   console.log("Found ", codeWarnings.length + " Code Warnings");
 
   const tokenList = props.tokenList;
@@ -56,18 +57,6 @@ export const CSVForm = (props: CSVFormProps) => {
     );
   };
 
-  const onChangeFileHandler = async (event: any) => {
-    console.log("Received Filename", event.target.files[0].name);
-
-    const reader = new FileReader();
-    reader.onload = function (evt) {
-      if (!evt.target) {
-        return;
-      }
-      props.onChange(evt.target.result as string);
-    };
-    reader.readAsText(event.target.files[0]);
-  };
   return (
     <Card>
       <Form>
@@ -108,31 +97,9 @@ export const CSVForm = (props: CSVFormProps) => {
             )}
           />
         </EditorWrapper>
-        <div>
-          <input
-            accept="*.csv"
-            id="csvUploadButton"
-            type="file"
-            name="file"
-            onChange={onChangeFileHandler}
-            style={{ display: "none" }}
-          />
-          <label htmlFor="csvUploadButton">
-            <Button
-              size="md"
-              variant="contained"
-              color="primary"
-              component="span"
-            >
-              Upload CSV
-            </Button>
-          </label>
-        </div>
-        <div>
-          <Link href="./sample.csv" download>
-            Sample Transfer File
-          </Link>
-        </div>
+
+        <CSVUpload onChange={props.onChange} />
+
         {props.transferContent.length > 0 && (
           <>
             <div>

--- a/src/components/CSVForm.tsx
+++ b/src/components/CSVForm.tsx
@@ -33,7 +33,7 @@ export interface CSVFormProps {
   onAbortSubmit: () => void;
 }
 
-export const CSVForm = (props: CSVFormProps) => {
+export const CSVForm = (props: CSVFormProps): JSX.Element => {
   const { codeWarnings } = useContext(MessageContext);
 
   console.log("Found ", codeWarnings.length + " Code Warnings");

--- a/src/components/CSVUpload.tsx
+++ b/src/components/CSVUpload.tsx
@@ -1,0 +1,121 @@
+import React, { useCallback, useMemo } from "react";
+import { useDropzone } from "react-dropzone";
+import { Button, Link, Text } from "@gnosis.pm/safe-react-components";
+import { createStyles } from "@material-ui/core";
+
+export type CSVUploadProps = {
+  onChange: (string) => void;
+};
+
+export const CSVUpload = (props: CSVUploadProps) => {
+  const { onChange } = props;
+  const onDrop = useCallback(
+    (acceptedFiles: File[]) => {
+      acceptedFiles.forEach((file) => {
+        console.log("Received Filename", file.name);
+        const reader = new FileReader();
+        reader.onload = function (evt) {
+          if (!evt.target) {
+            return;
+          }
+          onChange(evt.target.result as string);
+        };
+        reader.readAsText(file);
+      });
+    },
+    [onChange]
+  );
+
+  const {
+    getRootProps,
+    getInputProps,
+    isDragActive,
+    isDragAccept,
+    isDragReject,
+  } = useDropzone({
+    maxFiles: 1,
+    onDrop,
+    accept: "text/csv",
+  });
+
+  const style = useMemo(
+    () => ({
+      ...styles.baseStyle,
+      ...(isDragActive ? styles.activeStyle : {}),
+      ...(isDragAccept ? styles.acceptStyle : {}),
+      ...(isDragReject ? styles.rejectStyle : {}),
+    }),
+    [isDragActive, isDragReject, isDragAccept]
+  );
+
+  return (
+    <div>
+      <div {...getRootProps({ style })}>
+        <input {...getInputProps()} />
+        <input
+          accept="text/csv"
+          id="csvUploadButton"
+          type="file"
+          name="file"
+          onChange={onChange}
+          style={{ display: "none" }}
+        />
+        <label htmlFor="csvUploadButton">
+          <div
+            style={{
+              display: "inline-flex",
+              flexDirection: "row",
+              alignItems: "center",
+              gap: "8px",
+            }}
+          >
+            <Button
+              size="md"
+              variant="contained"
+              color="primary"
+              component="span"
+            >
+              Upload CSV
+            </Button>
+            <Text center size="lg">
+              or drop file here
+            </Text>
+          </div>
+        </label>
+      </div>
+      <div>
+        <Link href="./sample.csv" download>
+          Sample Transfer File
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+const styles = createStyles({
+  baseStyle: {
+    lex: 1,
+    display: "flex",
+    alignItems: "center",
+    flexDirection: "column",
+    padding: "20px",
+    borderWidth: 2,
+    borderRadius: 2,
+    width: "660px",
+    borderColor: "#eeeeee",
+    borderStyle: "dashed",
+    backgroundColor: "#fafafa",
+    color: "#bdbdbd",
+    outline: "none",
+    transition: "border .24s ease-in-out",
+  },
+  activeStyle: {
+    borderColor: "#2196f3",
+  },
+  acceptStyle: {
+    borderColor: "#008C73",
+  },
+  rejectStyle: {
+    borderColor: "#ff1744",
+  },
+});

--- a/src/components/CSVUpload.tsx
+++ b/src/components/CSVUpload.tsx
@@ -12,7 +12,7 @@ export type CSVUploadProps = {
   onChange: (string) => void;
 };
 
-export const CSVUpload = (props: CSVUploadProps) => {
+export const CSVUpload = (props: CSVUploadProps): JSX.Element => {
   const { onChange } = props;
   const onDrop = useCallback(
     (acceptedFiles: File[]) => {

--- a/src/components/CSVUpload.tsx
+++ b/src/components/CSVUpload.tsx
@@ -1,6 +1,11 @@
 import React, { useCallback, useMemo } from "react";
 import { useDropzone } from "react-dropzone";
-import { Button, Link, Text } from "@gnosis.pm/safe-react-components";
+import {
+  Button,
+  Link,
+  Text,
+  theme as GnosisTheme,
+} from "@gnosis.pm/safe-react-components";
 import { createStyles } from "@material-ui/core";
 
 export type CSVUploadProps = {
@@ -102,7 +107,7 @@ const styles = createStyles({
     borderWidth: 2,
     borderRadius: 2,
     width: "660px",
-    borderColor: "#eeeeee",
+    borderColor: "rgba(0, 0, 0, 0.23)",
     borderStyle: "dashed",
     backgroundColor: "#fafafa",
     color: "#bdbdbd",
@@ -113,9 +118,9 @@ const styles = createStyles({
     borderColor: "#2196f3",
   },
   acceptStyle: {
-    borderColor: "#008C73",
+    borderColor: GnosisTheme.colors.primary,
   },
   rejectStyle: {
-    borderColor: "#ff1744",
+    borderColor: GnosisTheme.colors.error,
   },
 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,7 +14,7 @@ const HeaderContainer = styled.div`
   width: 100%;
 `;
 
-export const Header = () => {
+export const Header = (): JSX.Element => {
   const messageContext = useContext(MessageContext);
   const messages = messageContext.messages;
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2953,6 +2953,11 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
+attr-accept@^2.2.1:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
+  integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
+
 autoprefixer@^9.6.1:
   version "9.8.6"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.8.6.tgz#3b73594ca1bf9266320c5acf1588d74dea74210f"
@@ -5752,6 +5757,13 @@ file-loader@4.3.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^2.5.0"
+
+file-selector@^0.2.2:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.2.4.tgz#7b98286f9dbb9925f420130ea5ed0a69238d4d80"
+  integrity sha512-ZDsQNbrv6qRi1YTDOEWzf5J2KjZ9KMI1Q2SGeTkCJmNNW25Jg4TW4UMcmoqcg4WrAyKRcpBXdbWRxkfrOzVRbA==
+  dependencies:
+    tslib "^2.0.3"
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -10529,6 +10541,15 @@ react-dom@^16.13.1:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.19.1"
+
+react-dropzone@^11.3.2:
+  version "11.3.2"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.3.2.tgz#2efb6af800a4779a9daa1e7ba1f8d51d0ab862d7"
+  integrity sha512-Z0l/YHcrNK1r85o6RT77Z5XgTARmlZZGfEKBl3tqTXL9fZNQDuIdRx/J0QjvR60X+yYu26dnHeaG2pWU+1HHvw==
+  dependencies:
+    attr-accept "^2.2.1"
+    file-selector "^0.2.2"
+    prop-types "^15.7.2"
 
 react-error-overlay@^6.0.7:
   version "6.0.9"


### PR DESCRIPTION
UI Changes:
* wraps the upload-button in a dropzone to enable easy drag and drop fileupload
* validates that we actually upload a text/csv file and otherwise refuses the upload

Here is a Screenshot of the new file-upload:
![Screenshot_2021-05-09 Gnosis Safe](https://user-images.githubusercontent.com/2670790/117574792-11565c00-b0df-11eb-877e-720028c55106.png)


Dependency changes:
 * new dependency react-dropzone

Refactors:
* moved CSVEditor into its own component

Fixes #6 