### PR TITLE
Update mainnet tokenlist

### DIFF
--- a/src/hooks/tokenList.ts
+++ b/src/hooks/tokenList.ts
@@ -22,7 +22,7 @@ export const fetchTokenList = async (
 ): Promise<TokenMap> => {
   let tokens: TokenInfo[];
   if (networkName === "MAINNET") {
-    const mainnetTokenURL = "https://gateway.ipfs.io/ipns/tokens.uniswap.org";
+    const mainnetTokenURL = "https://tokens.coingecko.com/uniswap/all.json";
     tokens = (await (await fetch(mainnetTokenURL)).json()).tokens;
   } else if (networkName === "RINKEBY") {
     // Hardcoded this because the list provided at
@@ -34,6 +34,7 @@ export const fetchTokenList = async (
   } else {
     console.error(`Unimplemented token list for ${networkName} network`);
   }
+  console.log(`Fetched ${tokens.length} for ${networkName} network`);
   return tokenMap(tokens);
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "sourceMap": true,
     "module": "esnext",
     "moduleResolution": "node",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "resolveJsonModule": true,
     "allowJs": false,
     "checkJs": false,


### PR DESCRIPTION
New token list (from coingecko) has 4219 entries instead of the 50 that `uniswap-default` had I think this is a substantial improvement and should be enough to close #29 without even having multiple combined tokenlists.

Screen shot shows some random shitcoins being found and displayed with icon. Also shows an error on the decimals column, which I assume will be solved by #5 

<img width="788" alt="Screenshot 2021-05-13 at 12 25 04" src="https://user-images.githubusercontent.com/11778116/118113770-fd647000-b3e6-11eb-9c23-6206479cc222.png">
