### PR TITLE
resolve token and receiver ens names if values are not addresses

### DIFF
--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -4,6 +4,7 @@ import * as chai from "chai";
 import { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
 
+import { EnsResolver } from "../hooks/ens";
 import { TokenMap, MinimalTokenInfo, fetchTokenList, TokenInfoProvider } from "../hooks/token";
 import { parseCSV } from "../parser";
 import { testData } from "../test/util";
@@ -27,29 +28,59 @@ const csvStringFromRows = (...rows: string[][]): string => {
 
 describe("Parsing CSVs ", () => {
   let mockTokenInfoProvider: TokenInfoProvider;
+  let mockEnsResolver: EnsResolver;
 
   beforeAll(async () => {
     tokenList = await fetchTokenList(testData.dummySafeInfo.network);
-    const fetchTokenFromList = async (tokenAddress: string) => {
-      return tokenList.get(tokenAddress);
-    };
-    mockTokenInfoProvider = {
-      getTokenInfo: fetchTokenFromList,
-    };
+    const fetchTokenFromList = async (tokenAddress: string) => tokenList.get(tokenAddress);
 
     let listedTokens = Array.from(tokenList.keys());
     const firstTokenInfo = tokenList.get(listedTokens[0]);
     if (typeof firstTokenInfo !== "undefined") {
       listedToken = firstTokenInfo;
     }
+
+    mockTokenInfoProvider = {
+      getTokenInfo: fetchTokenFromList,
+    };
+
+    mockEnsResolver = {
+      resolveName: async (ensName: string) => {
+        if (ensName.startsWith("0x")) {
+          return ensName;
+        }
+        switch (ensName) {
+          case "receiver1.eth":
+            return testData.addresses.receiver1;
+          case "receiver2.eth":
+            return testData.addresses.receiver2;
+          case "receiver3.eth":
+            return testData.addresses.receiver3;
+          case "token.eth":
+            return listedToken.address;
+          case "error.eth":
+            throw new Error("unexpected error!");
+          default:
+            return null;
+        }
+      },
+    };
   });
 
   it("should throw errors for invalid CSVs", async () => {
-    // thins csv contains more values than headers in row1
+    // this csv contains more values than headers in row1
     const invalidCSV = "head1,header2\nvalue1,value2,value3";
-    expect(parseCSV(invalidCSV, mockTokenInfoProvider)).to.be.rejectedWith(
+    expect(parseCSV(invalidCSV, mockTokenInfoProvider, mockEnsResolver)).to.be.rejectedWith(
       "column header mismatch expected: 2 columns got: 3",
     );
+  });
+
+  it("should throw errors for unexpected errors while parsing", async () => {
+    // we hard coded in our mock that a ens of "error.eth" throws an error.
+    const rowWithErrorReceiver = [listedToken.address, "error.eth", "1"];
+    expect(
+      parseCSV(csvStringFromRows(rowWithErrorReceiver), mockTokenInfoProvider, mockEnsResolver),
+    ).to.be.rejectedWith("unexpected error!");
   });
 
   it("should transform simple, valid CSVs correctly", async () => {
@@ -60,6 +91,7 @@ describe("Parsing CSVs ", () => {
     const [payment, warnings] = await parseCSV(
       csvStringFromRows(rowWithoutDecimal, rowWithDecimalAmount, rowWithoutTokenAddress),
       mockTokenInfoProvider,
+      mockEnsResolver,
     );
     expect(warnings).to.be.empty;
     expect(payment).to.have.lengthOf(3);
@@ -95,6 +127,7 @@ describe("Parsing CSVs ", () => {
         rowWithInvalidReceiverAddress,
       ),
       mockTokenInfoProvider,
+      mockEnsResolver,
     );
     expect(warnings).to.have.lengthOf(5);
     const [
@@ -121,5 +154,41 @@ describe("Parsing CSVs ", () => {
 
     expect(warningInvalidReceiverAddress.message).to.equal("Invalid Receiver Address: 0x420");
     expect(warningInvalidReceiverAddress.lineNo).to.equal(4);
+  });
+
+  it("tries to resolved ens names", async () => {
+    const receiverEnsName = [listedToken.address, "receiver1.eth", "1"];
+    const tokenEnsName = ["token.eth", validReceiverAddress, "69.420"];
+    const unknownReceiverEnsName = [listedToken.address, "unknown.eth", "1"];
+    const unknownTokenEnsName = ["unknown.eth", "receiver1.eth", "1"];
+
+    const [payment, warnings] = await parseCSV(
+      csvStringFromRows(receiverEnsName, tokenEnsName, unknownReceiverEnsName, unknownTokenEnsName),
+      mockTokenInfoProvider,
+      mockEnsResolver,
+    );
+
+    expect(warnings).to.have.lengthOf(3);
+    expect(payment).to.have.lengthOf(2);
+    const [paymentReceiverEnsName, paymentTokenEnsName] = payment;
+    const [warningUnknownReceiverEnsName, warningInvalidTokenAddress, warningInvalidContract] = warnings;
+    expect(paymentReceiverEnsName.decimals).to.be.equal(18);
+    expect(paymentReceiverEnsName.receiver).to.equal(testData.addresses.receiver1);
+    expect(paymentReceiverEnsName.tokenAddress).to.equal(listedToken.address);
+    expect(paymentReceiverEnsName.amount.isEqualTo(new BigNumber(1))).to.be.true;
+
+    expect(paymentTokenEnsName.receiver).to.equal(validReceiverAddress);
+    expect(paymentTokenEnsName.tokenAddress?.toLowerCase()).to.equal(listedToken.address.toLowerCase());
+    expect(paymentTokenEnsName.decimals).to.equal(18);
+    expect(paymentTokenEnsName.amount.isEqualTo(new BigNumber(69.42))).to.be.true;
+
+    expect(warningUnknownReceiverEnsName.lineNo).to.equal(3);
+    expect(warningUnknownReceiverEnsName.message).to.equal("Invalid Receiver Address: unknown.eth");
+
+    expect(warningInvalidTokenAddress.lineNo).to.equal(4);
+    expect(warningInvalidTokenAddress.message).to.equal("Invalid Token Address: unknown.eth");
+
+    expect(warningInvalidContract.lineNo).to.equal(4);
+    expect(warningInvalidContract.message).to.equal("No token contract was found at unknown.eth");
   });
 });

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -64,6 +64,20 @@ describe("Parsing CSVs ", () => {
             return null;
         }
       },
+      lookupAddress: async (address: string) => {
+        switch (address) {
+          case testData.addresses.receiver1:
+            return "receiver1.eth";
+          case testData.addresses.receiver2:
+            return "receiver2.eth";
+          case testData.addresses.receiver3:
+            return "receiver3.eth";
+          case listedToken.address:
+            return "token.eth";
+          default:
+            return null;
+        }
+      },
     };
   });
 
@@ -100,16 +114,19 @@ describe("Parsing CSVs ", () => {
     expect(paymentWithoutDecimal.receiver).to.equal(validReceiverAddress);
     expect(paymentWithoutDecimal.tokenAddress).to.equal(listedToken.address);
     expect(paymentWithoutDecimal.amount.isEqualTo(new BigNumber(1))).to.be.true;
+    expect(paymentWithoutDecimal.receiverEnsName).to.be.equal("receiver1.eth");
 
     expect(paymentWithDecimal.receiver).to.equal(validReceiverAddress);
     expect(paymentWithDecimal.tokenAddress?.toLowerCase()).to.equal(listedToken.address.toLowerCase());
     expect(paymentWithDecimal.decimals).to.equal(18);
     expect(paymentWithDecimal.amount.isEqualTo(new BigNumber(69.42))).to.be.true;
+    expect(paymentWithDecimal.receiverEnsName).to.be.equal("receiver1.eth");
 
     expect(paymentWithoutTokenAddress.decimals).to.be.equal(18);
     expect(paymentWithoutTokenAddress.receiver).to.equal(validReceiverAddress);
     expect(paymentWithoutTokenAddress.tokenAddress).to.equal(null);
     expect(paymentWithoutTokenAddress.amount.isEqualTo(new BigNumber(1))).to.be.true;
+    expect(paymentWithoutTokenAddress.receiverEnsName).to.be.equal("receiver1.eth");
   });
 
   it("should generate validation warnings", async () => {
@@ -176,11 +193,13 @@ describe("Parsing CSVs ", () => {
     expect(paymentReceiverEnsName.receiver).to.equal(testData.addresses.receiver1);
     expect(paymentReceiverEnsName.tokenAddress).to.equal(listedToken.address);
     expect(paymentReceiverEnsName.amount.isEqualTo(new BigNumber(1))).to.be.true;
+    expect(paymentReceiverEnsName.receiverEnsName).to.equal("receiver1.eth");
 
     expect(paymentTokenEnsName.receiver).to.equal(validReceiverAddress);
     expect(paymentTokenEnsName.tokenAddress?.toLowerCase()).to.equal(listedToken.address.toLowerCase());
     expect(paymentTokenEnsName.decimals).to.equal(18);
     expect(paymentTokenEnsName.amount.isEqualTo(new BigNumber(69.42))).to.be.true;
+    expect(paymentReceiverEnsName.receiverEnsName).to.equal("receiver1.eth");
 
     expect(warningUnknownReceiverEnsName.lineNo).to.equal(3);
     expect(warningUnknownReceiverEnsName.message).to.equal("Invalid Receiver Address: unknown.eth");

--- a/src/components/CSVForm.tsx
+++ b/src/components/CSVForm.tsx
@@ -7,6 +7,7 @@ import React, { useCallback, useContext, useMemo, useState } from "react";
 import styled from "styled-components";
 
 import { MessageContext } from "../contexts/MessageContextProvider";
+import { useEnsResolver } from "../hooks/ens";
 import { useTokenInfoProvider } from "../hooks/token";
 import { parseCSV, Payment } from "../parser";
 import { buildTransfers } from "../transfers";
@@ -37,6 +38,7 @@ export const CSVForm = (props: CSVFormProps): JSX.Element => {
   const { safe, sdk } = useSafeAppsSDK();
   const web3Provider = useMemo(() => new ethers.providers.Web3Provider(new SafeAppProvider(safe, sdk)), [safe, sdk]);
   const tokenInfoProvider = useTokenInfoProvider();
+  const ensResolver = useEnsResolver();
 
   const submitTx = useCallback(async () => {
     setSubmitting(true);
@@ -61,7 +63,7 @@ export const CSVForm = (props: CSVFormProps): JSX.Element => {
     () =>
       debounce((csvText: string) => {
         setParsing(true);
-        const parsePromise = parseCSV(csvText, tokenInfoProvider);
+        const parsePromise = parseCSV(csvText, tokenInfoProvider, ensResolver);
         parsePromise
           .then(([transfers, warnings]) => {
             const summary = transfersToSummary(transfers);
@@ -79,7 +81,7 @@ export const CSVForm = (props: CSVFormProps): JSX.Element => {
           })
           .catch((reason: any) => setMessages([{ severity: "error", message: reason.message }]));
       }, 1000),
-    [safe, setCodeWarnings, setMessages, tokenInfoProvider, web3Provider],
+    [ensResolver, safe, setCodeWarnings, setMessages, tokenInfoProvider, web3Provider],
   );
 
   return (
@@ -108,7 +110,7 @@ export const CSVForm = (props: CSVFormProps): JSX.Element => {
               </>
             ) : (
               <Button style={{ alignSelf: "center" }} size="lg" color="primary" onClick={submitTx} disabled={parsing}>
-                {parsing ? <Loader size="sm" /> : "Submit"}
+                {parsing ? <Loader size="sm" color="primaryLight" /> : "Submit"}
               </Button>
             )}
           </>

--- a/src/components/Receiver.tsx
+++ b/src/components/Receiver.tsx
@@ -1,0 +1,33 @@
+import { Icon, Text, Tooltip } from "@gnosis.pm/safe-react-components";
+import React from "react";
+import styled from "styled-components";
+
+type ReceiverProps = {
+  receiverEnsName: string | null;
+  receiverAddress: string;
+};
+
+const Container = styled.div`
+  flex: 1;
+  flex-direction: row;
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const Receiver = (props: ReceiverProps) => {
+  const { receiverEnsName, receiverAddress } = props;
+  return receiverEnsName !== null ? (
+    <Container>
+      <Text size="md">{receiverEnsName}</Text>
+      <Tooltip title={receiverAddress}>
+        <span>
+          <Icon type="info" size="sm" />
+        </span>
+      </Tooltip>
+    </Container>
+  ) : (
+    <Text size="md">{receiverAddress}</Text>
+  );
+};

--- a/src/components/Token.tsx
+++ b/src/components/Token.tsx
@@ -1,3 +1,6 @@
+import { Text } from "@gnosis.pm/safe-react-components";
+import styled from "styled-components";
+
 import { useTokenList } from "../hooks/token";
 
 type TokenProps = {
@@ -5,11 +8,20 @@ type TokenProps = {
   symbol?: string;
 };
 
+const Container = styled.div`
+  flex: 1;
+  flex-direction: row;
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  gap: 8px;
+`;
+
 export const Token = (props: TokenProps) => {
   const { tokenAddress, symbol } = props;
   const { tokenList } = useTokenList();
   return (
-    <div>
+    <Container>
       <img /* TODO - alt doesn't really work here */
         alt={""}
         src={tokenList.get(tokenAddress)?.logoURI}
@@ -19,7 +31,7 @@ export const Token = (props: TokenProps) => {
           verticalAlign: "middle",
         }}
       />{" "}
-      {symbol || tokenAddress}
-    </div>
+      <Text size="md">{symbol || tokenAddress}</Text>
+    </Container>
   );
 };

--- a/src/components/TransferTable.tsx
+++ b/src/components/TransferTable.tsx
@@ -1,8 +1,9 @@
-import { Table } from "@gnosis.pm/safe-react-components";
+import { Table, Text } from "@gnosis.pm/safe-react-components";
 import React from "react";
 
 import { Payment } from "../parser";
 
+import { Receiver } from "./Receiver";
 import { Token } from "./Token";
 
 type TransferTableProps = {
@@ -24,8 +25,11 @@ export const TransferTable = (props: TransferTableProps) => {
             id: "" + index,
             cells: [
               { id: "token", content: <Token tokenAddress={row.tokenAddress} symbol={row.symbol} /> },
-              { id: "receiver", content: row.receiver },
-              { id: "amount", content: row.amount.toString() },
+              {
+                id: "receiver",
+                content: <Receiver receiverAddress={row.receiver} receiverEnsName={row.receiverEnsName} />,
+              },
+              { id: "amount", content: <Text size="md">{row.amount.toString()}</Text> },
             ],
           };
         })}

--- a/src/hooks/ens.ts
+++ b/src/hooks/ens.ts
@@ -1,28 +1,65 @@
 import { SafeAppProvider } from "@gnosis.pm/safe-apps-provider";
 import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk";
 import { ethers } from "ethers";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 export interface EnsResolver {
   /**
    * Resolves a ENS name to a corresponding address.
    * Important: If the name is already a valid address, this address will be returned.
    *
-   * Returns null if the ENS name cannot be resolved.
+   * @returns null if the ENS name cannot be resolved.
    *
    * @param ensName ENS Name or address.
    */
   resolveName(ensName: string): Promise<string | null>;
+
+  /**
+   * Looks up the ENS name of an address.
+   *
+   * @returns null if no ENS name is registered for that address.
+   * @param address address to lookup
+   */
+  lookupAddress(address: string): Promise<string | null>;
 }
 
 export const useEnsResolver: () => EnsResolver = () => {
   const { safe, sdk } = useSafeAppsSDK();
   const web3Provider = useMemo(() => new ethers.providers.Web3Provider(new SafeAppProvider(safe, sdk)), [sdk, safe]);
 
+  const resolveCache = useMemo(() => new Map<string, string | null>(), []);
+
+  const lookupCache = useMemo(() => new Map<string, string | null>(), []);
+
+  const cachedResolveName = useCallback(
+    async (ensName: string) => {
+      const cachedAddress = resolveCache.get(ensName);
+      const resolvedAddress = cachedAddress ? cachedAddress : await web3Provider.resolveName(ensName);
+      if (!resolveCache.has(ensName)) {
+        resolveCache.set(ensName, resolvedAddress);
+      }
+      return resolvedAddress;
+    },
+    [resolveCache, web3Provider],
+  );
+
+  const cachedLookupAddress = useCallback(
+    async (address: string) => {
+      const cachedAddress = lookupCache.get(address);
+      const resolvedEnsName = cachedAddress ? cachedAddress : await web3Provider.lookupAddress(address);
+      if (!lookupCache.has(address)) {
+        lookupCache.set(address, resolvedEnsName);
+      }
+      return resolvedEnsName;
+    },
+    [lookupCache, web3Provider],
+  );
+
   return useMemo(
     () => ({
-      resolveName: (ensName: string) => web3Provider.resolveName(ensName),
+      resolveName: (ensName: string) => cachedResolveName(ensName),
+      lookupAddress: (address: string) => cachedLookupAddress(address),
     }),
-    [web3Provider],
+    [cachedResolveName, cachedLookupAddress],
   );
 };

--- a/src/hooks/ens.ts
+++ b/src/hooks/ens.ts
@@ -1,0 +1,28 @@
+import { SafeAppProvider } from "@gnosis.pm/safe-apps-provider";
+import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk";
+import { ethers } from "ethers";
+import { useMemo } from "react";
+
+export interface EnsResolver {
+  /**
+   * Resolves a ENS name to a corresponding address.
+   * Important: If the name is already a valid address, this address will be returned.
+   *
+   * Returns null if the ENS name cannot be resolved.
+   *
+   * @param ensName ENS Name or address.
+   */
+  resolveName(ensName: string): Promise<string | null>;
+}
+
+export const useEnsResolver: () => EnsResolver = () => {
+  const { safe, sdk } = useSafeAppsSDK();
+  const web3Provider = useMemo(() => new ethers.providers.Web3Provider(new SafeAppProvider(safe, sdk)), [sdk, safe]);
+
+  return useMemo(
+    () => ({
+      resolveName: (ensName: string) => web3Provider.resolveName(ensName),
+    }),
+    [web3Provider],
+  );
+};

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -122,9 +122,11 @@ export async function toPayment(
   tokenInfoProvider: TokenInfoProvider,
   ensResolver: EnsResolver,
 ): Promise<Payment> {
-  let resolvedReceiverAddress = await ensResolver.resolveName(prePayment.receiver);
+  // depending on whether there is an ens name or an address provided we either resolve or lookup
+  let [resolvedReceiverAddress, receiverEnsName] = utils.isAddress(prePayment.receiver)
+    ? [prePayment.receiver, await ensResolver.lookupAddress(prePayment.receiver)]
+    : [await ensResolver.resolveName(prePayment.receiver), prePayment.receiver];
   resolvedReceiverAddress = resolvedReceiverAddress !== null ? resolvedReceiverAddress : prePayment.receiver;
-  let receiverEnsName = await ensResolver.lookupAddress(resolvedReceiverAddress);
   if (prePayment.tokenAddress === null) {
     // Native asset payment.
     return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,6 @@
     "noEmit": true,
     "noFallthroughCasesInSwitch": true
   },
-  //"exclude": ["./node_modules/"],
+  "exclude": ["./node_modules/"],
   "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,6 @@
     "noEmit": true,
     "noFallthroughCasesInSwitch": true
   },
-  "exclude": ["./node_modules/"],
+  //"exclude": ["./node_modules/"],
   "include": ["src"]
 }


### PR DESCRIPTION
* useEnsResolver Hook for easy access to ens resolver
* parser gets EnsResolver to resolve ens names while transforming to payments
* table still shows resolved address
* parser.test covers ens resolution


close #73 