### PR TITLE
make table scrollable and fixed height

### DIFF
--- a/src/GlobalStyle.ts
+++ b/src/GlobalStyle.ts
@@ -57,7 +57,7 @@ const GlobalStyle = createGlobalStyle`
     }
     .MuiTableContainer-root {
         overflow: auto;
-        height: 500px;
+        height: 750px;
     }
 `;
 

--- a/src/GlobalStyle.ts
+++ b/src/GlobalStyle.ts
@@ -48,6 +48,17 @@ const GlobalStyle = createGlobalStyle`
     .ace_tooltip {
         font-family: 'Averta' !important;
     }
+
+    .MuiTableCell-head {
+        position: sticky;
+        top: 0px;
+        background-color: #FFF;
+        box-shadow: 10px 2px 10px 0 rgba(40,54,61,0.18);
+    }
+    .MuiTableContainer-root {
+        overflow: auto;
+        height: 500px;
+    }
 `;
 
 export default GlobalStyle;

--- a/src/components/CSVEditor.tsx
+++ b/src/components/CSVEditor.tsx
@@ -24,7 +24,7 @@ export const CSVEditor = (props: CSVEditorProps): JSX.Element => {
         width={"700px"}
         mode={"text"}
         minLines={6}
-        maxLines={32}
+        maxLines={20}
         setOptions={{
           firstLineNumber: 0,
         }}


### PR DESCRIPTION
Small GUI change with big effect on huge tables.

Tables from https://github.com/gnosis/safe-react-components do not support sticky headers yet. I might open a PR there some time beause Material-UI supports those already and is used there.

So I hacked the CSS for now to make em sticky, fixed height and scrollable.