### PR TITLE
fix ens lookup cache

### DIFF
--- a/src/hooks/ens.ts
+++ b/src/hooks/ens.ts
@@ -46,7 +46,8 @@ export const useEnsResolver: () => EnsResolver = () => {
   const cachedLookupAddress = useCallback(
     async (address: string) => {
       const cachedAddress = lookupCache.get(address);
-      const resolvedEnsName = cachedAddress ? cachedAddress : await web3Provider.lookupAddress(address);
+      const resolvedEnsName =
+        typeof cachedAddress !== "undefined" ? cachedAddress : await web3Provider.lookupAddress(address);
       if (!lookupCache.has(address)) {
         lookupCache.set(address, resolvedEnsName);
       }


### PR DESCRIPTION
small bug fix for the ens lookup.

The cache did not cache null values and thus repeatedly looked up addresses who dont have an ENS Name.