### PR TITLE
Update App Description in manifest

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "short_name": "Safe Airdrop",
   "name": "CSV Airdrop",
-  "description": "Upload a CSV transfer file to send various tokens to arbitrarily many recipients",
+  "description": "Upload your CSV transfer file to send arbitrarily many tokens of various amounts to a list of recipients.",
   "iconPath": "logo.svg",
   "start_url": ".",
   "display": "standalone",


### PR DESCRIPTION
As requested in the Gnosis forum:

https://forum.gnosis.io/t/grant-application-safe-csv-airdrop/1293/10

> Perhaps we can change the app description to “Upload your CSV transfer file to send arbitrarily many tokens of various amounts to a list of recipients.”