### PR TITLE
add mergify config

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,22 @@
+pull_request_rules:
+  - name: Merge approved and green PRs with `merge when green` label
+    conditions:
+      - "#approved-reviews-by>=1"
+      - status-success~=^test \([0-9]+\.x, ubuntu-latest\)$
+      - base=main
+      - label=merge when green
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        commit_message: title+body
+  - name: Automatic merge for Dependabot pull requests
+    conditions:
+      - author~=^dependabot(|-preview)\[bot\]$
+      - status-success~=^test \([0-9]+\.x, ubuntu-latest\)$
+      - base=main
+    actions:
+      merge:
+        method: squash
+        strict: smart+fasttrack
+        commit_message: title+body


### PR DESCRIPTION
Adding Mergify configuration file with two rules.

1. Allow merge when green PR label to merge when green
2. Automatically merge all passing dependabot PRs.

This will also require a setting change enabling the mergify extension to the project.


Once merged, will test this by submitting a PR and seeing if the merge-when-green label does the right thing.