### PR TITLE
checks if selected network supports ens

### DIFF
--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -42,6 +42,7 @@ describe("Parsing CSVs ", () => {
 
     mockTokenInfoProvider = {
       getTokenInfo: fetchTokenFromList,
+      getNativeTokenSymbol: () => "ETH",
     };
 
     mockEnsResolver = {
@@ -78,6 +79,7 @@ describe("Parsing CSVs ", () => {
             return null;
         }
       },
+      isEnsEnabled: async () => true,
     };
   });
 
@@ -184,7 +186,6 @@ describe("Parsing CSVs ", () => {
       mockTokenInfoProvider,
       mockEnsResolver,
     );
-
     expect(warnings).to.have.lengthOf(3);
     expect(payment).to.have.lengthOf(2);
     const [paymentReceiverEnsName, paymentTokenEnsName] = payment;

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -50,6 +50,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ETH",
+        receiverEnsName: null,
       },
       {
         tokenAddress: null,
@@ -57,6 +58,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver2,
         decimals: 18,
         symbol: "ETH",
+        receiverEnsName: null,
       },
       {
         tokenAddress: null,
@@ -64,6 +66,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver3,
         decimals: 18,
         symbol: "ETH",
+        receiverEnsName: null,
       },
     ];
     const summary = transfersToSummary(transfers);
@@ -78,6 +81,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ETH",
+        receiverEnsName: null,
       },
       {
         tokenAddress: null,
@@ -85,6 +89,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver2,
         decimals: 18,
         symbol: "ETH",
+        receiverEnsName: null,
       },
       {
         tokenAddress: null,
@@ -92,6 +97,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver3,
         decimals: 18,
         symbol: "ETH",
+        receiverEnsName: null,
       },
     ];
     const summary = transfersToSummary(transfers);
@@ -106,6 +112,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ULT",
+        receiverEnsName: null,
       },
       {
         tokenAddress: testData.unlistedToken.address,
@@ -113,6 +120,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver2,
         decimals: 18,
         symbol: "ULT",
+        receiverEnsName: null,
       },
       {
         tokenAddress: testData.unlistedToken.address,
@@ -120,6 +128,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver3,
         decimals: 18,
         symbol: "ULT",
+        receiverEnsName: null,
       },
     ];
     const summary = transfersToSummary(transfers);
@@ -134,6 +143,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ULT",
+        receiverEnsName: null,
       },
       {
         tokenAddress: testData.unlistedToken.address,
@@ -141,6 +151,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver2,
         decimals: 18,
         symbol: "ULT",
+        receiverEnsName: null,
       },
       {
         tokenAddress: testData.unlistedToken.address,
@@ -148,6 +159,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver3,
         decimals: 18,
         symbol: "ULT",
+        receiverEnsName: null,
       },
     ];
     const summary = transfersToSummary(transfers);
@@ -162,6 +174,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ULT",
+        receiverEnsName: null,
       },
       {
         tokenAddress: testData.unlistedToken.address,
@@ -169,6 +182,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver2,
         decimals: 18,
         symbol: "ULT",
+        receiverEnsName: null,
       },
       {
         tokenAddress: testData.unlistedToken.address,
@@ -176,6 +190,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver3,
         decimals: 18,
         symbol: "ULT",
+        receiverEnsName: null,
       },
       {
         tokenAddress: null,
@@ -183,6 +198,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ETH",
+        receiverEnsName: null,
       },
       {
         tokenAddress: null,
@@ -190,6 +206,7 @@ describe("transferToSummary()", () => {
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ETH",
+        receiverEnsName: null,
       },
     ];
     const summary = transfersToSummary(transfers);

--- a/src/components/CSVForm.tsx
+++ b/src/components/CSVForm.tsx
@@ -73,10 +73,17 @@ export const CSVForm = (props: CSVFormProps): JSX.Element => {
             );
             if (uniqueReceiversWithoutEnsName.size < 15) {
               transfers = await Promise.all(
-                transfers.map(async (transfer) => ({
-                  ...transfer,
-                  receiverEnsName: await ensResolver.lookupAddress(transfer.receiver),
-                })),
+                // If there is no ENS Name we will try to lookup the address
+                transfers.map(async (transfer) =>
+                  transfer.receiverEnsName
+                    ? transfer
+                    : {
+                        ...transfer,
+                        receiverEnsName: (await ensResolver.isEnsEnabled())
+                          ? await ensResolver.lookupAddress(transfer.receiver)
+                          : null,
+                      },
+                ),
               );
             }
             const summary = transfersToSummary(transfers);

--- a/src/hooks/ens.ts
+++ b/src/hooks/ens.ts
@@ -21,6 +21,11 @@ export interface EnsResolver {
    * @param address address to lookup
    */
   lookupAddress(address: string): Promise<string | null>;
+
+  /**
+   * @returns true, if ENS is enabled for current network.
+   */
+  isEnsEnabled(): Promise<boolean>;
 }
 
 export const useEnsResolver: () => EnsResolver = () => {
@@ -56,11 +61,18 @@ export const useEnsResolver: () => EnsResolver = () => {
     [lookupCache, web3Provider],
   );
 
+  const isEnsEnabled = useCallback(async () => {
+    const network = await web3Provider.getNetwork();
+    console.log("ENS Address: " + network.ensAddress);
+    return typeof network.ensAddress !== "undefined" && network.ensAddress !== null;
+  }, [web3Provider]);
+
   return useMemo(
     () => ({
       resolveName: (ensName: string) => cachedResolveName(ensName),
       lookupAddress: (address: string) => cachedLookupAddress(address),
+      isEnsEnabled: () => isEnsEnabled(),
     }),
-    [cachedResolveName, cachedLookupAddress],
+    [cachedResolveName, cachedLookupAddress, isEnsEnabled],
   );
 };

--- a/src/hooks/ens.ts
+++ b/src/hooks/ens.ts
@@ -63,7 +63,6 @@ export const useEnsResolver: () => EnsResolver = () => {
 
   const isEnsEnabled = useCallback(async () => {
     const network = await web3Provider.getNetwork();
-    console.log("ENS Address: " + network.ensAddress);
     return typeof network.ensAddress !== "undefined" && network.ensAddress !== null;
   }, [web3Provider]);
 

--- a/src/hooks/token.ts
+++ b/src/hooks/token.ts
@@ -79,6 +79,7 @@ export type MinimalTokenInfo = {
 
 export interface TokenInfoProvider {
   getTokenInfo: (tokenAddress: string) => Promise<MinimalTokenInfo | undefined>;
+  getNativeTokenSymbol: () => string;
 }
 
 export const useTokenInfoProvider: () => TokenInfoProvider = () => {
@@ -108,7 +109,8 @@ export const useTokenInfoProvider: () => TokenInfoProvider = () => {
           }
         }
       },
+      getNativeTokenSymbol: () => (safe.chainId === 100 ? "xDai" : "ETH"),
     }),
-    [tokenList, web3Provider],
+    [safe.chainId, tokenList, web3Provider],
   );
 };

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -126,7 +126,10 @@ export async function toPayment(
   // For performance reasons the lookup will be done after the parsing.
   let [resolvedReceiverAddress, receiverEnsName] = utils.isAddress(prePayment.receiver)
     ? [prePayment.receiver, null]
-    : [await ensResolver.resolveName(prePayment.receiver), prePayment.receiver];
+    : [
+        (await ensResolver.isEnsEnabled()) ? await ensResolver.resolveName(prePayment.receiver) : null,
+        prePayment.receiver,
+      ];
   resolvedReceiverAddress = resolvedReceiverAddress !== null ? resolvedReceiverAddress : prePayment.receiver;
   if (prePayment.tokenAddress === null) {
     // Native asset payment.
@@ -135,11 +138,13 @@ export async function toPayment(
       amount: prePayment.amount,
       tokenAddress: prePayment.tokenAddress,
       decimals: 18,
-      symbol: "ETH",
+      symbol: tokenInfoProvider.getNativeTokenSymbol(),
       receiverEnsName,
     };
   }
-  let resolvedTokenAddress = await ensResolver.resolveName(prePayment.tokenAddress);
+  let resolvedTokenAddress = (await ensResolver.isEnsEnabled())
+    ? await ensResolver.resolveName(prePayment.tokenAddress)
+    : prePayment.tokenAddress;
   const tokenInfo =
     resolvedTokenAddress === null ? undefined : await tokenInfoProvider.getTokenInfo(resolvedTokenAddress);
   if (typeof tokenInfo !== "undefined") {


### PR DESCRIPTION
- if ens is not supported by current network, no lookup / resolution will take place.
- in xDai network we display xDai instead of ETH for native transfers

fixes #152