### PR TITLE
Bump safe apps dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   },
   "dependencies": {
     "@fast-csv/parse": "^4.3.6",
-    "@gnosis.pm/safe-apps-provider": "^0.7.0",
-    "@gnosis.pm/safe-apps-react-sdk": "^4.0.1",
-    "@gnosis.pm/safe-apps-sdk": "^4.1.0",
+    "@gnosis.pm/safe-apps-provider": "^0.7.1",
+    "@gnosis.pm/safe-apps-react-sdk": "^4.0.3",
+    "@gnosis.pm/safe-apps-sdk": "^4.2.0",
     "@gnosis.pm/safe-react-components": "^0.7.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/lab": "^4.0.0-alpha.60",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@gnosis.pm/safe-apps-provider": "^0.7.1",
     "@gnosis.pm/safe-apps-react-sdk": "^4.0.3",
     "@gnosis.pm/safe-apps-sdk": "^4.2.0",
-    "@gnosis.pm/safe-react-components": "^0.7.0",
+    "@gnosis.pm/safe-react-components": "^0.8.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/lab": "^4.0.0-alpha.60",
     "@openzeppelin/contracts": "^4.3.0",

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -5,6 +5,8 @@ import { TokenInfo } from "../utils";
 const dummySafeInfo: SafeInfo = {
   safeAddress: "0x123",
   chainId: 4,
+  threshold: 1,
+  owners: [],
 };
 
 const unlistedToken: TokenInfo = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,12 +1633,11 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-4.2.0.tgz#77069de1b4f3db724d1ded1fab39e1feacc7bc05"
   integrity sha512-GpaxIbi658+KLtJpTGq6qdpVkbW7OQUKh8i0uhZ04SiAoIAtR9QNbP7V04OvvuqhKjhvCnvh37mJH2RZ2zZHDA==
 
-"@gnosis.pm/safe-react-components@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-components/-/safe-react-components-0.7.0.tgz#395031c777a8e77d946d7c3aae1b17548cceffd2"
-  integrity sha512-e2cON1P61parOGxvtIlQH3CqxpSFzK8nKOBKh4XPm2FIoH1lCanf3EUjWdvdNE2EAsgn33T5ErsC3R+pPywISQ==
+"@gnosis.pm/safe-react-components@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-components/-/safe-react-components-0.8.0.tgz#1c957f53c08833f9c8f2f2908c19b6823f573578"
+  integrity sha512-IZy1Mv3y93QBi0Edph85mhKnndc4Uo6uHe5dmz8MHe3htNWa0JxwsI3Afrzqqidvx+LLNsfguNvpu/ZRHbycvw==
   dependencies:
-    classnames "^2.2.6"
     react-media "^1.10.0"
 
 "@hapi/address@2.x.x":
@@ -3914,11 +3913,6 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
-
-classnames@^2.2.6:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
-  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
 clean-css@^4.2.3:
   version "4.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1613,25 +1613,25 @@
     lodash.isundefined "^3.0.1"
     lodash.uniq "^4.5.0"
 
-"@gnosis.pm/safe-apps-provider@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.7.0.tgz#12cc7f4dec904f4010174386d3eb3690a1022073"
-  integrity sha512-n7som0FTKuEApO1IRL8c/zU+dKpEPzOtIVHErANOD2ml744xu0ytb2pT3mM6NLzM+/s6oMs4BCJBC71Bpttlzg==
+"@gnosis.pm/safe-apps-provider@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.7.1.tgz#d55ba011cd496322faa346a50c1b6aea64b1da43"
+  integrity sha512-+y+hQ9Zr1GGrzehqdkhOUTEX1Ixm0jGUGMxbXQbG4C3PJRvQ2UVoqIXa7CJcqg0Gzru2bOM5CzNvv8pxxv23GA==
   dependencies:
-    "@gnosis.pm/safe-apps-sdk" "4.1.0"
+    "@gnosis.pm/safe-apps-sdk" "4.2.0"
     events "^3.3.0"
 
-"@gnosis.pm/safe-apps-react-sdk@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-react-sdk/-/safe-apps-react-sdk-4.0.1.tgz#3be05270f6bdf325d05dbc1b23fef5129aaa7794"
-  integrity sha512-rv0bM5u4lUGahLLfxzSu55uX3+bXKCnLQRlBT96iCUZdFUz90mWopfp1giLpWft75bx5KvuN8F56qVe0ikh85A==
+"@gnosis.pm/safe-apps-react-sdk@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-react-sdk/-/safe-apps-react-sdk-4.0.3.tgz#14eda4890e641e151d67ba3f6b0a37ffcefe245c"
+  integrity sha512-hJUKuAnTwMfgwO2EETwVe9qKDa4xwHR4y2nAwyUmdjsRkiIbQLqIGTDBYoCElH2ZxQS8/PJVWZ5efT6cB83i+Q==
   dependencies:
-    "@gnosis.pm/safe-apps-sdk" "4.1.0"
+    "@gnosis.pm/safe-apps-sdk" "4.2.0"
 
-"@gnosis.pm/safe-apps-sdk@4.1.0", "@gnosis.pm/safe-apps-sdk@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-4.1.0.tgz#95187bba585836a8f02d4eaa88c65568e8b51ef7"
-  integrity sha512-j9soWW1BeKtSQpyRr5ZeidEV1owuqEZvZkV1Vg7D8zlTmV5N72PJHnLUn7k7KzUDGxzicVuvEE7Wqkc7AWrc/Q==
+"@gnosis.pm/safe-apps-sdk@4.2.0", "@gnosis.pm/safe-apps-sdk@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-4.2.0.tgz#77069de1b4f3db724d1ded1fab39e1feacc7bc05"
+  integrity sha512-GpaxIbi658+KLtJpTGq6qdpVkbW7OQUKh8i0uhZ04SiAoIAtR9QNbP7V04OvvuqhKjhvCnvh37mJH2RZ2zZHDA==
 
 "@gnosis.pm/safe-react-components@^0.7.0":
   version "0.7.0"


### PR DESCRIPTION
As we have seen nearly every week, all the `safe-apps-*` dependencies must be bumped together in order to build.

Superseding #195, #197, #198 & #200 (opened by dependabot)