### PR TITLE
remove css hack for sticky table headers

### DIFF
--- a/src/GlobalStyle.ts
+++ b/src/GlobalStyle.ts
@@ -54,17 +54,6 @@ const GlobalStyle = createGlobalStyle`
         margin-top: 16px;
     }
 
-    .MuiTableCell-head {
-        position: sticky;
-        top: 0px;
-        background-color: #FFF;
-        box-shadow: 10px 2px 10px 0 #F7F5F5;
-    }
-    .MuiTableContainer-root {
-        overflow: auto;
-        max-height: 750px;
-    }
-
     .MuiPaper-elevation3 {
         box-shadow: 0px 3px 3px -2px #F7F5F5,0px 3px 4px 0px #F7F5F5,0px 1px 8px 0px #F7F5F5 !important;
     }

--- a/src/components/TransferTable.tsx
+++ b/src/components/TransferTable.tsx
@@ -15,6 +15,8 @@ export const TransferTable = (props: TransferTableProps) => {
   return (
     <div>
       <Table
+        isStickyHeader={true}
+        maxHeight={750}
         headers={[
           { id: "token", label: "Token" },
           { id: "receiver", label: "Receiver" },


### PR DESCRIPTION
my PR at the gnosis react components got merged and released.
So now we can just pass in some props for a sticky table header and a max height.