### PR TITLE
Display app even for unknown networks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,7 +51,7 @@ const App: React.FC = () => {
   return (
     <Container>
       <Header />
-      {networkMap.has(safe.chainId) ? (
+      {
         <>
           {isLoading ? (
             <>
@@ -85,9 +85,7 @@ const App: React.FC = () => {
             </Card>
           )}
         </>
-      ) : (
-        <Text size={"xl"}>Network with chainId {safe.chainId} not yet supported.</Text>
-      )}
+      }
       <FAQModal />
     </Container>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,7 @@ import { FAQModal } from "./components/FAQModal";
 import { Header } from "./components/Header";
 import { Summary } from "./components/Summary";
 import { CSVForm } from "./components/assets/CSVForm";
-import { useTokenList, networkMap } from "./hooks/token";
+import { useTokenList } from "./hooks/token";
 import { AssetTransfer, CollectibleTransfer, Transfer } from "./parser/csvParser";
 import { buildAssetTransfers, buildCollectibleTransfers } from "./transfers/transfers";
 
@@ -17,7 +17,6 @@ setUseWhatChange(process.env.NODE_ENV === "development");
 
 const App: React.FC = () => {
   const { isLoading } = useTokenList();
-  const { safe } = useSafeAppsSDK();
   const [tokenTransfers, setTokenTransfers] = useState<Transfer[]>([]);
 
   const [submitting, setSubmitting] = useState(false);


### PR DESCRIPTION
If this works, this PR closes #324

By removing the "unsupported network" page for unknown networks. 

This version is deployed at IPFS hash: QmTef26dDY2XABj84ioRBpFk7vZPRmSkNJ2eYJeKMnTMk9

and can be tested by loading this app into the safe interface 

https://bafybeiepy5xhantx776xnp5pb3442de3kp4owmoc36e5ni23optcauam44.ipfs.infura-ipfs.io/

Please try it out @sirpy and let us know if this is what you were hoping for.