### PR TITLE
WIP: Block gas limit display

### DIFF
--- a/src/components/GasUsage.tsx
+++ b/src/components/GasUsage.tsx
@@ -1,0 +1,145 @@
+import { BaseTransaction, SafeInfo } from "@gnosis.pm/safe-apps-sdk";
+import { Text, Title, Tooltip } from "@gnosis.pm/safe-react-components";
+import BigNumber from "bignumber.js";
+import { AssetTransfer, CollectibleTransfer } from "src/parser/csvParser";
+import { buildAssetTransfers, buildCollectibleTransfers } from "src/transfers/transfers";
+
+const CIRCLE_RADIUS = 28;
+const CIRCLE_DIAMETER = CIRCLE_RADIUS * 2;
+const CIRCUMFERENCE = CIRCLE_RADIUS * 2 * Math.PI;
+const STROKE_WIDTH = 4;
+
+// TODO: These are just very rough by looking at 2 TX each on etherscan
+const NATIVE_ESTIMATION = new BigNumber(21_000);
+const ERC20_ESTIMATION = new BigNumber(60_000);
+const ERC721_ESTIMATION = new BigNumber(200_000);
+const ERC1155_ESTIMATION = new BigNumber(100_000);
+const COST_PER_OWNER = new BigNumber(7_000);
+const BASE_COST = new BigNumber(21_000);
+const DATA_NULL_BYTE_COST = 4;
+const DATA_NON_NULL_BYTE_COST = 16;
+
+interface GasUsageProperties {
+  assetTransfers: AssetTransfer[];
+  collectibleTransfers: CollectibleTransfer[];
+  blockGasLimit: BigNumber;
+  safe: SafeInfo;
+}
+
+/**
+ * Component which estimates the transaction gas limit and computes the percentage of block gas limit used.
+ *
+ * This is displayed as small circle diagram. When more than 60% of the network's block gas limit is used the circle turns red.
+ *
+ *
+ * We estimate quite roughly as described here:
+ * https://help.gnosis-safe.io/en/articles/4933491-gas-estimation
+ *
+ * Although the execution costs are based on pessimistic estimations for each transfer type.
+ */
+export const GasUsage = (props: GasUsageProperties): JSX.Element => {
+  const { assetTransfers, collectibleTransfers, blockGasLimit, safe } = props;
+
+  const sigCheckTotal = COST_PER_OWNER.times(safe.threshold);
+  const txs: BaseTransaction[] = [];
+  txs.push(...buildAssetTransfers(assetTransfers));
+  txs.push(...buildCollectibleTransfers(collectibleTransfers));
+  const dataTotal = txs.reduce(
+    (prev, curr) =>
+      prev.plus(
+        curr.data
+          .substr(2)
+          .split("")
+          .reduce(
+            (prev, curr) => (curr === "0" ? prev.plus(DATA_NULL_BYTE_COST) : prev.plus(DATA_NON_NULL_BYTE_COST)),
+            new BigNumber(0),
+          ),
+      ),
+    new BigNumber(0),
+  );
+  const erc20Total = ERC20_ESTIMATION.times(assetTransfers.filter((value) => value.tokenAddress !== null).length);
+  const nativeTotal = NATIVE_ESTIMATION.times(assetTransfers.filter((value) => value.tokenAddress === null).length);
+  const erc721Total = ERC721_ESTIMATION.times(
+    collectibleTransfers.filter((value) => value.token_type === "erc721").length,
+  );
+  const erc1155Total = ERC1155_ESTIMATION.times(
+    collectibleTransfers.filter((value) => value.token_type === "erc1155").length,
+  );
+  const totalGasUsed = erc20Total
+    .plus(nativeTotal)
+    .plus(erc721Total)
+    .plus(erc1155Total)
+    .plus(sigCheckTotal)
+    .plus(dataTotal)
+    .plus(BASE_COST);
+
+  const percentageUsed = totalGasUsed.dividedBy(blockGasLimit).times(100);
+  const percentageUsedRounded = percentageUsed.decimalPlaces(2).toNumber();
+
+  const strokeColor = percentageUsedRounded < 60 ? "#001428" : "#DB3A3D";
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        position: "relative",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+        }}
+      >
+        <Title size="xs">Block gas limit</Title>
+        <Tooltip title={`${totalGasUsed} / ${blockGasLimit}`}>
+          <div
+            style={{
+              border: `${STROKE_WIDTH}px solid #d2d2d1`,
+              borderRadius: 999,
+              background: "#fff",
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              flexDirection: "column",
+              aspectRatio: "1/1",
+              height: CIRCLE_DIAMETER + STROKE_WIDTH,
+              width: CIRCLE_DIAMETER + STROKE_WIDTH,
+              boxSizing: "border-box",
+            }}
+          >
+            <svg
+              viewBox={`0 0 ${CIRCLE_DIAMETER + STROKE_WIDTH} ${CIRCLE_DIAMETER + STROKE_WIDTH}`}
+              width={CIRCLE_DIAMETER + STROKE_WIDTH}
+              height={CIRCLE_DIAMETER + STROKE_WIDTH}
+              style={{ position: "absolute" }}
+            >
+              <circle
+                stroke={strokeColor}
+                stroke-width={STROKE_WIDTH}
+                fill="transparent"
+                r={CIRCLE_RADIUS}
+                cx={CIRCLE_RADIUS + STROKE_WIDTH / 2}
+                cy={CIRCLE_RADIUS + STROKE_WIDTH / 2}
+                style={{
+                  strokeDasharray: `${CIRCUMFERENCE} ${CIRCUMFERENCE}`,
+                  strokeDashoffset: CIRCUMFERENCE - (Math.min(100, percentageUsedRounded) / 100) * CIRCUMFERENCE,
+                  transition: "stroke-dashoffset .35s, stroke .35s",
+                  transform: "rotate(-90deg)",
+                  transformOrigin: "50% 50%",
+                }}
+              />
+            </svg>
+            <div>
+              <Text size="sm" strong>
+                {percentageUsedRounded} %
+              </Text>
+            </div>
+            <Text size="sm">used</Text>
+          </div>
+        </Tooltip>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Summary.tsx
+++ b/src/components/Summary.tsx
@@ -1,7 +1,11 @@
+import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk";
 import { Accordion, AccordionDetails, AccordionSummary, Icon, Text } from "@gnosis.pm/safe-react-components";
+import BigNumber from "bignumber.js";
+import { networkInfo } from "src/networks";
 
 import { AssetTransfer, CollectibleTransfer } from "../parser/csvParser";
 
+import { GasUsage } from "./GasUsage";
 import { AssetTransferTable } from "./assets/AssetTransferTable";
 import { CollectiblesTransferTable } from "./assets/CollectiblesTransferTable";
 
@@ -14,6 +18,8 @@ export const Summary = (props: SummaryProps): JSX.Element => {
   const { assetTransfers, collectibleTransfers } = props;
   const assetTxCount = assetTransfers.length;
   const collectibleTxCount = collectibleTransfers.length;
+  const { safe } = useSafeAppsSDK();
+
   return (
     <>
       <Accordion disabled={assetTxCount === 0} compact style={{ maxWidth: 1400 }}>
@@ -68,6 +74,12 @@ export const Summary = (props: SummaryProps): JSX.Element => {
           {collectibleTransfers.length > 0 && <CollectiblesTransferTable transferContent={collectibleTransfers} />}
         </AccordionDetails>
       </Accordion>
+      <GasUsage
+        assetTransfers={assetTransfers}
+        collectibleTransfers={collectibleTransfers}
+        safe={safe}
+        blockGasLimit={networkInfo.get(safe.chainId)?.blockGasLimit ?? new BigNumber(30_000_000)}
+      />
     </>
   );
 };

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -1,10 +1,13 @@
-type NetworkInfo = {
+import BigNumber from "bignumber.js";
+
+interface NetworkInfo {
   shortName: string;
   chainID: number;
   name: string;
   currencySymbol: string;
   baseAPI?: string;
-};
+  blockGasLimit: BigNumber;
+}
 
 export const networkInfo = new Map<number, NetworkInfo>([
   [
@@ -15,6 +18,7 @@ export const networkInfo = new Map<number, NetworkInfo>([
       shortName: "eth",
       currencySymbol: "ETH",
       baseAPI: "https://safe-transaction.gnosis.io/api/v1",
+      blockGasLimit: new BigNumber(30_000_000),
     },
   ],
   [
@@ -25,6 +29,7 @@ export const networkInfo = new Map<number, NetworkInfo>([
       shortName: "rin",
       currencySymbol: "RIN",
       baseAPI: "https://safe-transaction.rinkeby.gnosis.io/api/v1",
+      blockGasLimit: new BigNumber(30_000_000),
     },
   ],
   [
@@ -35,6 +40,7 @@ export const networkInfo = new Map<number, NetworkInfo>([
       shortName: "gor",
       currencySymbol: "GOR",
       baseAPI: "https://safe-transaction.goerli.gnosis.io/api/v1",
+      blockGasLimit: new BigNumber(30_000_000),
     },
   ],
   [
@@ -45,6 +51,7 @@ export const networkInfo = new Map<number, NetworkInfo>([
       shortName: "oeth",
       currencySymbol: "OETH",
       baseAPI: "https://safe-transaction.optimism.gnosis.io/api/v1",
+      blockGasLimit: new BigNumber(30_000_000),
     },
   ],
   [
@@ -55,6 +62,7 @@ export const networkInfo = new Map<number, NetworkInfo>([
       shortName: "bnb",
       currencySymbol: "BNB",
       baseAPI: "https://safe-transaction.bsc.gnosis.io/api/v1",
+      blockGasLimit: new BigNumber(80_000_000),
     },
   ],
   [
@@ -65,6 +73,7 @@ export const networkInfo = new Map<number, NetworkInfo>([
       shortName: "xdai", // gno this is the offical shortname. wierdly gnosis Safe still uses xdai
       currencySymbol: "xDAI",
       baseAPI: "https://safe-transaction.xdai.gnosis.io/api/v1",
+      blockGasLimit: new BigNumber(30_000_000),
     },
   ],
   [
@@ -75,6 +84,7 @@ export const networkInfo = new Map<number, NetworkInfo>([
       shortName: "matic",
       currencySymbol: "MATIC",
       baseAPI: "https://safe-transaction.polygon.gnosis.io/api/v1",
+      blockGasLimit: new BigNumber(30_000_000),
     },
   ],
   [
@@ -84,6 +94,7 @@ export const networkInfo = new Map<number, NetworkInfo>([
       name: "Energy Web Chain",
       shortName: "ewt",
       currencySymbol: "EWT",
+      blockGasLimit: new BigNumber(30_000_000),
     },
   ],
   [
@@ -94,6 +105,7 @@ export const networkInfo = new Map<number, NetworkInfo>([
       shortName: "arb1",
       currencySymbol: "AETH",
       baseAPI: "https://safe-transaction.arbitrum.gnosis.io/api/v1",
+      blockGasLimit: new BigNumber(200_000_000),
     },
   ],
   [
@@ -104,6 +116,7 @@ export const networkInfo = new Map<number, NetworkInfo>([
       shortName: "avax",
       currencySymbol: "AVAX",
       baseAPI: "https://safe-transaction.avalanche.gnosis.io/api/v1",
+      blockGasLimit: new BigNumber(30_000_000),
     },
   ],
   [
@@ -114,6 +127,7 @@ export const networkInfo = new Map<number, NetworkInfo>([
       shortName: "vt",
       currencySymbol: "VT",
       baseAPI: "https://safe-transaction.volta.gnosis.io/api/v1",
+      blockGasLimit: new BigNumber(30_000_000),
     },
   ],
 ]);


### PR DESCRIPTION
This is still work in progress.

I wanna build a new component to display a good gas estimation and the percentage used in the network's block gas limit.

Here is a gif of the current component. I'm very happy with it so far.
![new_gas_estimation](https://user-images.githubusercontent.com/2670790/154355324-b152aaed-a8e7-4d15-9fa7-d5f05efabee2.gif)


Resources used so far:
- https://help.gnosis-safe.io/en/articles/4933491-gas-estimation
- very rough estimations for the `Safe tx execution` part of the estimation
-  waiting on reply on this question: https://ethereum.stackexchange.com/questions/121785/gas-estimation-fails-on-gnosis-safe-transaction-service-api-gnosis-chain