### PR TITLE
Bump Safe Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
   },
   "dependencies": {
     "@fast-csv/parse": "^4.3.6",
-    "@gnosis.pm/safe-apps-provider": "^0.11.0",
-    "@gnosis.pm/safe-apps-react-sdk": "^4.3.1",
+    "@gnosis.pm/safe-apps-provider": "^0.11.2",
+    "@gnosis.pm/safe-apps-react-sdk": "^4.5.0",
     "@gnosis.pm/safe-apps-sdk": "^7.4.1",
-    "@gnosis.pm/safe-react-components": "^1.1.2",
+    "@gnosis.pm/safe-react-components": "^1.1.4",
     "@material-ui/core": "^4.12.3",
     "@material-ui/lab": "^4.0.0-alpha.60",
     "@openzeppelin/contracts": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1509,30 +1509,22 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@gnosis.pm/safe-apps-provider@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.11.0.tgz#e8fece9bb09dc5179895bb8f3a75f8cddcfdf18c"
-  integrity sha512-XTEXa5iCk0XOZQkgwHcpzP3sOmT9kYsieY5Bfmlrj7GSuApxnn8PnA7tQuzCOrrH2PbT+nspY04h4aBDDJaKrw==
+"@gnosis.pm/safe-apps-provider@^0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-provider/-/safe-apps-provider-0.11.2.tgz#4fb1716c1d6a3760a9ade4925a59fb4a099a006b"
+  integrity sha512-ddXgB6wEvVHY0Nb2PvCBtbM9DE+K81d+mX+tdP929Q4lCeccgtga7PtbUfY2i5LAqV7zEXiCMPXyKlnDjP9zFA==
   dependencies:
-    "@gnosis.pm/safe-apps-sdk" "7.3.0"
+    "@gnosis.pm/safe-apps-sdk" "7.4.1"
     events "^3.3.0"
 
-"@gnosis.pm/safe-apps-react-sdk@^4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-react-sdk/-/safe-apps-react-sdk-4.3.1.tgz#eab045829eefa1bb9e4b1d24f8a3ccebbee59d95"
-  integrity sha512-0pvG7xYZHRSiEv1Dh6KweBjWQiI32jRuMKnIDS/VLLVpq/+8LhSGbgTcO1j/rM7vfNnT0KX5PgHQP25XF489RA==
+"@gnosis.pm/safe-apps-react-sdk@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-react-sdk/-/safe-apps-react-sdk-4.5.0.tgz#5b961c5fbdf850601847091338a5b966b66fbc27"
+  integrity sha512-CVx/gWSJk7/rtgw1KRlOO7bmF5fW3/rw7Ezq/SG3qiEl33Imj5stv/Lm8ucQegyO0cujW/pTVeAmFj7OjdAGUA==
   dependencies:
-    "@gnosis.pm/safe-apps-sdk" "7.3.0"
+    "@gnosis.pm/safe-apps-sdk" "7.4.1"
 
-"@gnosis.pm/safe-apps-sdk@7.3.0":
-  version "7.3.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-7.3.0.tgz#3a3ed38b75657a7d5cd58d5a6884ec60087b05a8"
-  integrity sha512-1f6VHJWqPRKAEg/m+fbO1XiaDrsTcI3PQg31A0ciHATlVVoh35BYXryijaQxXblLzz4eDgbbIXQdNAH683j87Q==
-  dependencies:
-    "@gnosis.pm/safe-react-gateway-sdk" "^2.10.0"
-    ethers "^5.4.7"
-
-"@gnosis.pm/safe-apps-sdk@^7.4.1":
+"@gnosis.pm/safe-apps-sdk@7.4.1", "@gnosis.pm/safe-apps-sdk@^7.4.1":
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-apps-sdk/-/safe-apps-sdk-7.4.1.tgz#3e397b3f54e5d1be7977f1dcb4cd3785eff721b3"
   integrity sha512-l00IIKnSxd6qfTGyrh9FgP1Bx0rKwwGym9WOVrTY6E8PMDjg8z0qxTFhN7Qoc7pnvVa0kmtbZFcuuxgiOHFUzQ==
@@ -1540,20 +1532,13 @@
     "@gnosis.pm/safe-react-gateway-sdk" "^3.1.1"
     ethers "^5.6.8"
 
-"@gnosis.pm/safe-react-components@^1.1.2":
+"@gnosis.pm/safe-react-components@^1.1.4":
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-components/-/safe-react-components-1.1.4.tgz#4db12424bd0227fa28148230d231e61cd145ebe6"
   integrity sha512-OrVP54gc05dY1H6PrVk/vz6Fg0yFrCoNB9FER+s/1q/nnVMCkeW6/qA3Cr87O9MOmTql/gy+PO9jQJXYvRkYvg==
   dependencies:
     react-media "^1.10.0"
     web3-utils "^1.6.0"
-
-"@gnosis.pm/safe-react-gateway-sdk@^2.10.0":
-  version "2.10.3"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-react-gateway-sdk/-/safe-react-gateway-sdk-2.10.3.tgz#4537442a78eb0508c483aabcac19296335a77ac3"
-  integrity sha512-ukaLACozdJQb2YGSAZgBUkF4CT9iKVjpnKFCKUnGGghXqp+Yyn9jpdcfFK0VYQJ6ZSwAm40tHtQaN3K9817Bcg==
-  dependencies:
-    cross-fetch "^3.1.5"
 
 "@gnosis.pm/safe-react-gateway-sdk@^3.1.1":
   version "3.1.3"
@@ -5770,7 +5755,7 @@ ethereumjs-util@^7.1.0:
     ethereum-cryptography "^0.1.3"
     rlp "^2.2.4"
 
-ethers@^5.4.7, ethers@^5.6.2, ethers@^5.6.8:
+ethers@^5.6.2, ethers@^5.6.8:
   version "5.6.9"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.6.9.tgz#4e12f8dfcb67b88ae7a78a9519b384c23c576a4d"
   integrity sha512-lMGC2zv9HC5EC+8r429WaWu3uWJUCgUCt8xxKCFqkrFuBDZXDYIdzDUECxzjf2BMF8IVBByY1EBoGSL3RTm8RA==


### PR DESCRIPTION
Dependabot can't handle safe dependency version bumps, we have to do it manually.