### PR TITLE
Migrate BigNumber Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@material-ui/lab": "^4.0.0-alpha.60",
     "@openzeppelin/contracts": "^4.7.2",
     "ace-builds": "^1.10.0",
-    "bignumber.js": "^9.0.2",
     "ethers": "^5.6.2",
     "honeyswap-default-token-list": "^3.1.1",
     "lodash.debounce": "^4.0.8",

--- a/src/__tests__/balanceCheck.test.ts
+++ b/src/__tests__/balanceCheck.test.ts
@@ -1,5 +1,5 @@
-import BigNumber from "bignumber.js";
 import { expect } from "chai";
+import { BigNumber } from "ethers";
 
 import { AssetBalance, CollectibleBalance } from "../hooks/balances";
 import { assetTransfersToSummary, checkAllBalances } from "../parser/balanceCheck";
@@ -13,7 +13,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "native",
         tokenAddress: null,
-        amount: new BigNumber(1),
+        amount: BigNumber.from(1),
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ETH",
@@ -22,7 +22,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "native",
         tokenAddress: null,
-        amount: new BigNumber(2),
+        amount: BigNumber.from(2),
         receiver: testData.addresses.receiver2,
         decimals: 18,
         symbol: "ETH",
@@ -31,7 +31,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "native",
         tokenAddress: null,
-        amount: new BigNumber(3),
+        amount: BigNumber.from(3),
         receiver: testData.addresses.receiver3,
         decimals: 18,
         symbol: "ETH",
@@ -39,13 +39,13 @@ describe("transferToSummary and check balances", () => {
       },
     ];
     const summary = assetTransfersToSummary(transfers);
-    expect(summary.get(null)?.amount.toFixed()).to.equal("6");
+    expect(summary.get(null)?.amount.toString()).to.equal("6");
 
     const exactBalance: AssetBalance = [
       {
         token: null,
         tokenAddress: null,
-        balance: toWei("6", 18).toFixed(),
+        balance: toWei("6", 18).toString(),
         decimals: 18,
       },
     ];
@@ -53,7 +53,7 @@ describe("transferToSummary and check balances", () => {
       {
         token: null,
         tokenAddress: null,
-        balance: toWei("7", 18).toFixed(),
+        balance: toWei("7", 18).toString(),
         decimals: 18,
       },
     ];
@@ -61,7 +61,7 @@ describe("transferToSummary and check balances", () => {
       {
         token: null,
         tokenAddress: null,
-        balance: toWei("5.999999999999", 18).toFixed(),
+        balance: toWei("5.999999999999", 18).toString(),
         decimals: 18,
       },
     ];
@@ -80,7 +80,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "native",
         tokenAddress: null,
-        amount: new BigNumber(0.1),
+        amount: BigNumber.from(0.1),
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ETH",
@@ -89,7 +89,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "native",
         tokenAddress: null,
-        amount: new BigNumber(0.01),
+        amount: BigNumber.from(0.01),
         receiver: testData.addresses.receiver2,
         decimals: 18,
         symbol: "ETH",
@@ -98,7 +98,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "native",
         tokenAddress: null,
-        amount: new BigNumber(0.001),
+        amount: BigNumber.from(0.001),
         receiver: testData.addresses.receiver3,
         decimals: 18,
         symbol: "ETH",
@@ -106,13 +106,13 @@ describe("transferToSummary and check balances", () => {
       },
     ];
     const summary = assetTransfersToSummary(transfers);
-    expect(summary.get(null)?.amount.toFixed()).to.equal("0.111");
+    expect(summary.get(null)?.amount.toString()).to.equal("0.111");
 
     const exactBalance: AssetBalance = [
       {
         token: null,
         tokenAddress: null,
-        balance: toWei("0.111", 18).toFixed(),
+        balance: toWei("0.111", 18).toString(),
         decimals: 18,
       },
     ];
@@ -120,7 +120,7 @@ describe("transferToSummary and check balances", () => {
       {
         token: null,
         tokenAddress: null,
-        balance: toWei("0.1111", 18).toFixed(),
+        balance: toWei("0.1111", 18).toString(),
         decimals: 18,
       },
     ];
@@ -128,7 +128,7 @@ describe("transferToSummary and check balances", () => {
       {
         token: null,
         tokenAddress: null,
-        balance: toWei("0.11", 18).toFixed(),
+        balance: toWei("0.11", 18).toString(),
         decimals: 18,
       },
     ];
@@ -147,7 +147,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "erc20",
         tokenAddress: testData.unlistedERC20Token.address,
-        amount: new BigNumber(0.1),
+        amount: BigNumber.from(0.1),
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ULT",
@@ -156,7 +156,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "erc20",
         tokenAddress: testData.unlistedERC20Token.address,
-        amount: new BigNumber(0.01),
+        amount: BigNumber.from(0.01),
         receiver: testData.addresses.receiver2,
         decimals: 18,
         symbol: "ULT",
@@ -165,7 +165,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "erc20",
         tokenAddress: testData.unlistedERC20Token.address,
-        amount: new BigNumber(0.001),
+        amount: BigNumber.from(0.001),
         receiver: testData.addresses.receiver3,
         decimals: 18,
         symbol: "ULT",
@@ -173,7 +173,7 @@ describe("transferToSummary and check balances", () => {
       },
     ];
     const summary = assetTransfersToSummary(transfers);
-    expect(summary.get(testData.unlistedERC20Token.address)?.amount.toFixed()).to.equal("0.111");
+    expect(summary.get(testData.unlistedERC20Token.address)?.amount.toString()).to.equal("0.111");
 
     const exactBalance: AssetBalance = [
       {
@@ -183,7 +183,7 @@ describe("transferToSummary and check balances", () => {
           name: "Unlisted Token",
         },
         tokenAddress: testData.unlistedERC20Token.address,
-        balance: toWei("0.111", 18).toFixed(),
+        balance: toWei("0.111", 18).toString(),
         decimals: 18,
       },
     ];
@@ -195,7 +195,7 @@ describe("transferToSummary and check balances", () => {
           name: "Unlisted Token",
         },
         tokenAddress: testData.unlistedERC20Token.address,
-        balance: toWei("0.1111", 18).toFixed(),
+        balance: toWei("0.1111", 18).toString(),
         decimals: 18,
       },
     ];
@@ -207,7 +207,7 @@ describe("transferToSummary and check balances", () => {
           name: "Unlisted Token",
         },
         tokenAddress: testData.unlistedERC20Token.address,
-        balance: toWei("0.11", 18).toFixed(),
+        balance: toWei("0.11", 18).toString(),
         decimals: 18,
       },
     ];
@@ -226,7 +226,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "erc20",
         tokenAddress: testData.unlistedERC20Token.address,
-        amount: new BigNumber(1),
+        amount: BigNumber.from(1),
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ULT",
@@ -235,7 +235,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "erc20",
         tokenAddress: testData.unlistedERC20Token.address,
-        amount: new BigNumber(2),
+        amount: BigNumber.from(2),
         receiver: testData.addresses.receiver2,
         decimals: 18,
         symbol: "ULT",
@@ -244,7 +244,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "erc20",
         tokenAddress: testData.unlistedERC20Token.address,
-        amount: new BigNumber(3),
+        amount: BigNumber.from(3),
         receiver: testData.addresses.receiver3,
         decimals: 18,
         symbol: "ULT",
@@ -252,7 +252,7 @@ describe("transferToSummary and check balances", () => {
       },
     ];
     const summary = assetTransfersToSummary(transfers);
-    expect(summary.get(testData.unlistedERC20Token.address)?.amount.toFixed()).to.equal("6");
+    expect(summary.get(testData.unlistedERC20Token.address)?.amount.toString()).to.equal("6");
 
     const exactBalance: AssetBalance = [
       {
@@ -262,7 +262,7 @@ describe("transferToSummary and check balances", () => {
           name: "Unlisted Token",
         },
         tokenAddress: testData.unlistedERC20Token.address,
-        balance: toWei("6", 18).toFixed(),
+        balance: toWei("6", 18).toString(),
         decimals: 18,
       },
     ];
@@ -274,7 +274,7 @@ describe("transferToSummary and check balances", () => {
           name: "Unlisted Token",
         },
         tokenAddress: testData.unlistedERC20Token.address,
-        balance: toWei("7", 18).toFixed(),
+        balance: toWei("7", 18).toString(),
         decimals: 18,
       },
     ];
@@ -286,7 +286,7 @@ describe("transferToSummary and check balances", () => {
           name: "Unlisted Token",
         },
         tokenAddress: testData.unlistedERC20Token.address,
-        balance: toWei("5.999999999999", 18).toFixed(),
+        balance: toWei("5.999999999999", 18).toString(),
         decimals: 18,
       },
     ];
@@ -305,7 +305,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "erc20",
         tokenAddress: testData.unlistedERC20Token.address,
-        amount: new BigNumber(1.1),
+        amount: BigNumber.from(1.1),
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ULT",
@@ -314,7 +314,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "erc20",
         tokenAddress: testData.unlistedERC20Token.address,
-        amount: new BigNumber(2),
+        amount: BigNumber.from(2),
         receiver: testData.addresses.receiver2,
         decimals: 18,
         symbol: "ULT",
@@ -323,7 +323,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "erc20",
         tokenAddress: testData.unlistedERC20Token.address,
-        amount: new BigNumber(3.3),
+        amount: BigNumber.from(3.3),
         receiver: testData.addresses.receiver3,
         decimals: 18,
         symbol: "ULT",
@@ -332,7 +332,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "native",
         tokenAddress: null,
-        amount: new BigNumber(3),
+        amount: BigNumber.from(3),
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ETH",
@@ -341,7 +341,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "native",
         tokenAddress: null,
-        amount: new BigNumber(0.33),
+        amount: BigNumber.from(0.33),
         receiver: testData.addresses.receiver1,
         decimals: 18,
         symbol: "ETH",
@@ -349,14 +349,14 @@ describe("transferToSummary and check balances", () => {
       },
     ];
     const summary = assetTransfersToSummary(transfers);
-    expect(summary.get(testData.unlistedERC20Token.address)?.amount.toFixed()).to.equal("6.4");
-    expect(summary.get(null)?.amount.toFixed()).to.equal("3.33");
+    expect(summary.get(testData.unlistedERC20Token.address)?.amount.toString()).to.equal("6.4");
+    expect(summary.get(null)?.amount.toString()).to.equal("3.33");
 
     const exactBalance: AssetBalance = [
       {
         token: null,
         tokenAddress: null,
-        balance: toWei("3.33", 18).toFixed(),
+        balance: toWei("3.33", 18).toString(),
         decimals: 18,
       },
       {
@@ -366,7 +366,7 @@ describe("transferToSummary and check balances", () => {
           name: "Unlisted Token",
         },
         tokenAddress: testData.unlistedERC20Token.address,
-        balance: toWei("6.4", 18).toFixed(),
+        balance: toWei("6.4", 18).toString(),
         decimals: 18,
       },
     ];
@@ -374,7 +374,7 @@ describe("transferToSummary and check balances", () => {
       {
         token: null,
         tokenAddress: null,
-        balance: toWei("3.34", 18).toFixed(),
+        balance: toWei("3.34", 18).toString(),
         decimals: 18,
       },
       {
@@ -384,7 +384,7 @@ describe("transferToSummary and check balances", () => {
           name: "Unlisted Token",
         },
         tokenAddress: testData.unlistedERC20Token.address,
-        balance: toWei("6.5", 18).toFixed(),
+        balance: toWei("6.5", 18).toString(),
         decimals: 18,
       },
     ];
@@ -392,7 +392,7 @@ describe("transferToSummary and check balances", () => {
       {
         token: null,
         tokenAddress: null,
-        balance: toWei("3.32", 18).toFixed(),
+        balance: toWei("3.32", 18).toString(),
         decimals: 18,
       },
       {
@@ -402,7 +402,7 @@ describe("transferToSummary and check balances", () => {
           name: "Unlisted Token",
         },
         tokenAddress: testData.unlistedERC20Token.address,
-        balance: toWei("6.3", 18).toFixed(),
+        balance: toWei("6.3", 18).toString(),
         decimals: 18,
       },
     ];
@@ -411,7 +411,7 @@ describe("transferToSummary and check balances", () => {
       {
         token: null,
         tokenAddress: null,
-        balance: toWei("3.32", 18).toFixed(),
+        balance: toWei("3.32", 18).toString(),
         decimals: 18,
       },
       {
@@ -421,7 +421,7 @@ describe("transferToSummary and check balances", () => {
           name: "Unlisted Token",
         },
         tokenAddress: testData.unlistedERC20Token.address,
-        balance: toWei("69", 18).toFixed(),
+        balance: toWei("69", 18).toString(),
         decimals: 18,
       },
     ];
@@ -453,7 +453,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "erc721",
         tokenAddress: testData.unlistedERC20Token.address,
-        tokenId: new BigNumber(69),
+        tokenId: BigNumber.from(69),
         receiver: testData.addresses.receiver1,
         tokenName: "Test Collectible",
         receiverEnsName: null,
@@ -463,7 +463,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "erc721",
         tokenAddress: testData.unlistedERC20Token.address,
-        tokenId: new BigNumber(420),
+        tokenId: BigNumber.from(420),
         receiver: testData.addresses.receiver1,
         tokenName: "Test Collectible",
         receiverEnsName: null,
@@ -521,7 +521,7 @@ describe("transferToSummary and check balances", () => {
     expect(smallBalanceCheckResult).to.have.length(1);
     expect(smallBalanceCheckResult[0].token).to.equal("Test Collectible");
     expect(smallBalanceCheckResult[0].token_type).to.equal("erc721");
-    expect(smallBalanceCheckResult[0].id?.toFixed()).to.equal("420");
+    expect(smallBalanceCheckResult[0].id?.toString()).to.equal("420");
     expect(smallBalanceCheckResult[0].transferAmount).to.be.undefined;
     expect(smallBalanceCheckResult[0].isDuplicate).to.be.false;
   });
@@ -531,7 +531,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "erc721",
         tokenAddress: testData.unlistedERC20Token.address,
-        tokenId: new BigNumber(69),
+        tokenId: BigNumber.from(69),
         receiver: testData.addresses.receiver1,
         receiverEnsName: null,
         hasMetaData: false,
@@ -540,7 +540,7 @@ describe("transferToSummary and check balances", () => {
       {
         token_type: "erc721",
         tokenAddress: testData.unlistedERC20Token.address,
-        tokenId: new BigNumber(69),
+        tokenId: BigNumber.from(69),
         receiver: testData.addresses.receiver2,
         receiverEnsName: null,
         hasMetaData: false,
@@ -561,7 +561,7 @@ describe("transferToSummary and check balances", () => {
     expect(balanceCheckResult).to.have.length(1);
     expect(balanceCheckResult[0].token).to.equal("Test Collectible");
     expect(balanceCheckResult[0].token_type).to.equal("erc721");
-    expect(balanceCheckResult[0].id?.toFixed()).to.equal("69");
+    expect(balanceCheckResult[0].id?.toString()).to.equal("69");
     expect(balanceCheckResult[0].transferAmount).to.undefined;
     expect(balanceCheckResult[0].isDuplicate).to.be.true;
   });

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -1,7 +1,7 @@
-import { BigNumber } from "bignumber.js";
 import * as chai from "chai";
 import { expect } from "chai";
 import chaiAsPromised from "chai-as-promised";
+import { BigNumber } from "ethers";
 
 import { CollectibleTokenInfoProvider } from "../hooks/collectibleTokenInfoProvider";
 import { EnsResolver } from "../hooks/ens";
@@ -147,19 +147,19 @@ describe("Parsing CSVs ", () => {
     expect(paymentWithoutDecimal.decimals).to.be.equal(18);
     expect(paymentWithoutDecimal.receiver).to.equal(validReceiverAddress);
     expect(paymentWithoutDecimal.tokenAddress).to.equal(listedToken.address);
-    expect(paymentWithoutDecimal.amount.isEqualTo(new BigNumber(1))).to.be.true;
+    expect(paymentWithoutDecimal.amount.eq(BigNumber.from(1))).to.be.true;
     expect(paymentWithoutDecimal.receiverEnsName).to.be.null;
 
     expect(paymentWithDecimal.receiver).to.equal(validReceiverAddress);
     expect(paymentWithDecimal.tokenAddress?.toLowerCase()).to.equal(listedToken.address.toLowerCase());
     expect(paymentWithDecimal.decimals).to.equal(18);
-    expect(paymentWithDecimal.amount.isEqualTo(new BigNumber(69.42))).to.be.true;
+    expect(paymentWithDecimal.amount.eq(BigNumber.from(69.42))).to.be.true;
     expect(paymentWithDecimal.receiverEnsName).to.be.null;
 
     expect(paymentWithoutTokenAddress.decimals).to.be.equal(18);
     expect(paymentWithoutTokenAddress.receiver).to.equal(validReceiverAddress);
     expect(paymentWithoutTokenAddress.tokenAddress).to.equal(null);
-    expect(paymentWithoutTokenAddress.amount.isEqualTo(new BigNumber(1))).to.be.true;
+    expect(paymentWithoutTokenAddress.amount.eq(BigNumber.from(1))).to.be.true;
     expect(paymentWithoutTokenAddress.receiverEnsName).to.be.null;
   });
 
@@ -232,13 +232,13 @@ describe("Parsing CSVs ", () => {
     expect(paymentReceiverEnsName.decimals).to.be.equal(18);
     expect(paymentReceiverEnsName.receiver).to.equal(testData.addresses.receiver1);
     expect(paymentReceiverEnsName.tokenAddress).to.equal(listedToken.address);
-    expect(paymentReceiverEnsName.amount.isEqualTo(new BigNumber(1))).to.be.true;
+    expect(paymentReceiverEnsName.amount.eq(BigNumber.from(1))).to.be.true;
     expect(paymentReceiverEnsName.receiverEnsName).to.equal("receiver1.eth");
 
     expect(paymentTokenEnsName.receiver).to.equal(validReceiverAddress);
     expect(paymentTokenEnsName.tokenAddress?.toLowerCase()).to.equal(listedToken.address.toLowerCase());
     expect(paymentTokenEnsName.decimals).to.equal(18);
-    expect(paymentTokenEnsName.amount.isEqualTo(new BigNumber(69.42))).to.be.true;
+    expect(paymentTokenEnsName.amount.eq(BigNumber.from(69.42))).to.be.true;
     expect(paymentReceiverEnsName.receiverEnsName).to.equal("receiver1.eth");
 
     expect(warningUnknownReceiverEnsName.lineNo).to.equal(3);
@@ -282,18 +282,18 @@ describe("Parsing CSVs ", () => {
     expect(transferErc721AndAddress.receiver).to.equal(validReceiverAddress);
     expect(transferErc721AndAddress.tokenAddress).to.equal(testData.addresses.dummyErc721Address);
     expect(transferErc721AndAddress.amount).to.be.undefined;
-    expect(transferErc721AndAddress.tokenId.isEqualTo(new BigNumber(1))).to.be.true;
+    expect(transferErc721AndAddress.tokenId.eq(BigNumber.from(1))).to.be.true;
     expect(transferErc721AndAddress.receiverEnsName).to.be.null;
 
     expect(transferErc721AndENS.receiver).to.equal(testData.addresses.receiver2);
     expect(transferErc721AndENS.tokenAddress).to.equal(testData.addresses.dummyErc721Address);
-    expect(transferErc721AndENS.tokenId.isEqualTo(new BigNumber(69))).to.be.true;
+    expect(transferErc721AndENS.tokenId.eq(BigNumber.from(69))).to.be.true;
     expect(transferErc721AndENS.amount).to.be.undefined;
     expect(transferErc721AndENS.receiverEnsName).to.equal("receiver2.eth");
 
     expect(transferErc721AndIDZero.receiver).to.equal(testData.addresses.receiver1);
     expect(transferErc721AndIDZero.tokenAddress).to.equal(testData.addresses.dummyErc721Address);
-    expect(transferErc721AndIDZero.tokenId.isEqualTo(new BigNumber(0))).to.be.true;
+    expect(transferErc721AndIDZero.tokenId.eq(BigNumber.from(0))).to.be.true;
     expect(transferErc721AndIDZero.amount).to.be.undefined;
     expect(transferErc721AndIDZero.receiverEnsName).to.equal("receiver1.eth");
 
@@ -302,8 +302,8 @@ describe("Parsing CSVs ", () => {
       testData.addresses.dummyErc1155Address.toLowerCase(),
     );
     expect(transferErc1155AndAddress.amount).not.to.be.undefined;
-    expect(transferErc1155AndAddress.amount?.isEqualTo(new BigNumber(69))).to.be.true;
-    expect(transferErc1155AndAddress.tokenId.isEqualTo(new BigNumber(420))).to.be.true;
+    expect(transferErc1155AndAddress.amount?.eq(BigNumber.from(69))).to.be.true;
+    expect(transferErc1155AndAddress.tokenId.eq(BigNumber.from(420))).to.be.true;
     expect(transferErc1155AndAddress.receiverEnsName).to.be.null;
 
     expect(transferErc1155AndENS.receiver).to.equal(testData.addresses.receiver3);
@@ -311,8 +311,8 @@ describe("Parsing CSVs ", () => {
       testData.addresses.dummyErc1155Address.toLowerCase(),
     );
     expect(transferErc1155AndENS.amount).not.to.be.undefined;
-    expect(transferErc1155AndENS.amount?.isEqualTo(new BigNumber(9))).to.be.true;
-    expect(transferErc1155AndENS.tokenId.isEqualTo(new BigNumber(99))).to.be.true;
+    expect(transferErc1155AndENS.amount?.eq(BigNumber.from(9))).to.be.true;
+    expect(transferErc1155AndENS.tokenId.eq(BigNumber.from(99))).to.be.true;
     expect(transferErc1155AndENS.receiverEnsName).to.equal("receiver3.eth");
   });
 
@@ -473,7 +473,7 @@ describe("Parsing CSVs ", () => {
       expect(payment).to.have.length(1);
       const [nativeTransferData] = payment as AssetTransfer[];
 
-      expect(nativeTransferData.amount.isEqualTo(new BigNumber(15))).to.be.true;
+      expect(nativeTransferData.amount.eq(BigNumber.from(15))).to.be.true;
     });
   });
 });

--- a/src/__tests__/transfers.test.ts
+++ b/src/__tests__/transfers.test.ts
@@ -1,6 +1,5 @@
-import { BigNumber } from "bignumber.js";
 import { expect } from "chai";
-import { ethers } from "ethers";
+import { ethers, BigNumber } from "ethers";
 
 import { fetchTokenList, MinimalTokenInfo } from "../hooks/token";
 import { AssetTransfer, CollectibleTransfer } from "../parser/csvParser";
@@ -64,16 +63,16 @@ describe("Build Transfers:", () => {
       expect(listedTransfer.value).to.be.equal("0");
       expect(listedTransfer.to).to.be.equal(listedToken.address);
       expect(listedTransfer.data).to.be.equal(
-        erc20Interface.encodeFunctionData("transfer", [receiver, MAX_U256.toFixed()]),
+        erc20Interface.encodeFunctionData("transfer", [receiver, MAX_U256.toString()]),
       );
 
       expect(unlistedTransfer.value).to.be.equal("0");
       expect(unlistedTransfer.to).to.be.equal(testData.unlistedERC20Token.address);
       expect(unlistedTransfer.data).to.be.equal(
-        erc20Interface.encodeFunctionData("transfer", [receiver, MAX_U256.toFixed()]),
+        erc20Interface.encodeFunctionData("transfer", [receiver, MAX_U256.toString()]),
       );
 
-      expect(nativeTransfer.value).to.be.equal(MAX_U256.toFixed());
+      expect(nativeTransfer.value).to.be.equal(MAX_U256.toString());
       expect(nativeTransfer.to).to.be.equal(receiver);
       expect(nativeTransfer.data).to.be.equal("0x");
     });
@@ -81,7 +80,7 @@ describe("Build Transfers:", () => {
 
   describe("Decimals", () => {
     it("works with decimal payments on listed, unlisted and native transfers", () => {
-      const tinyAmount = new BigNumber("0.0000001");
+      const tinyAmount = BigNumber.from("0.0000001");
       const smallPayments: AssetTransfer[] = [
         // Listed ERC20
         {
@@ -119,7 +118,7 @@ describe("Build Transfers:", () => {
       expect(listed.value).to.be.equal("0");
       expect(listed.to).to.be.equal(listedToken.address);
       expect(listed.data).to.be.equal(
-        erc20Interface.encodeFunctionData("transfer", [receiver, toWei(tinyAmount, listedToken.decimals).toFixed()]),
+        erc20Interface.encodeFunctionData("transfer", [receiver, toWei(tinyAmount, listedToken.decimals).toString()]),
       );
 
       expect(unlisted.value).to.be.equal("0");
@@ -127,7 +126,7 @@ describe("Build Transfers:", () => {
       expect(unlisted.data).to.be.equal(
         erc20Interface.encodeFunctionData("transfer", [
           receiver,
-          toWei(tinyAmount, testData.unlistedERC20Token.decimals).toFixed(),
+          toWei(tinyAmount, testData.unlistedERC20Token.decimals).toString(),
         ]),
       );
 
@@ -139,7 +138,7 @@ describe("Build Transfers:", () => {
 
   describe("Mixed", () => {
     it("works with arbitrary value strings on listed, unlisted and native transfers", () => {
-      const mixedAmount = new BigNumber("123456.000000789");
+      const mixedAmount = BigNumber.from("123456.000000789");
       const mixedPayments: AssetTransfer[] = [
         // Listed ERC20
         {
@@ -177,7 +176,7 @@ describe("Build Transfers:", () => {
       expect(listed.value).to.be.equal("0");
       expect(listed.to).to.be.equal(listedToken.address);
       expect(listed.data).to.be.equal(
-        erc20Interface.encodeFunctionData("transfer", [receiver, toWei(mixedAmount, listedToken.decimals).toFixed()]),
+        erc20Interface.encodeFunctionData("transfer", [receiver, toWei(mixedAmount, listedToken.decimals).toString()]),
       );
 
       expect(unlisted.value).to.be.equal("0");
@@ -185,11 +184,11 @@ describe("Build Transfers:", () => {
       expect(unlisted.data).to.be.equal(
         erc20Interface.encodeFunctionData("transfer", [
           receiver,
-          toWei(mixedAmount, testData.unlistedERC20Token.decimals).toFixed(),
+          toWei(mixedAmount, testData.unlistedERC20Token.decimals).toString(),
         ]),
       );
 
-      expect(native.value).to.be.equal(toWei(mixedAmount, 18).toFixed());
+      expect(native.value).to.be.equal(toWei(mixedAmount, 18).toString());
       expect(native.to).to.be.equal(receiver);
       expect(native.data).to.be.equal("0x");
     });
@@ -197,7 +196,7 @@ describe("Build Transfers:", () => {
 
   describe("Truncation on too many decimals", () => {
     it("cuts fractional part of token with 0 decimals", () => {
-      const amount = new BigNumber("1.000000789");
+      const amount = 1.000000789;
       const crappyToken: TokenInfo = {
         address: "0x6b175474e89094c44da98b954eedeac495271d0f",
         decimals: 0,
@@ -219,7 +218,7 @@ describe("Build Transfers:", () => {
       expect(transfer.value).to.be.equal("0");
       expect(transfer.to).to.be.equal(crappyToken.address);
       expect(transfer.data).to.be.equal(
-        erc20Interface.encodeFunctionData("transfer", [receiver, toWei(amount, crappyToken.decimals).toFixed()]),
+        erc20Interface.encodeFunctionData("transfer", [receiver, toWei(amount, crappyToken.decimals).toString()]),
       );
     });
   });
@@ -233,7 +232,7 @@ describe("Build Transfers:", () => {
         receiverEnsName: null,
         tokenAddress: testData.addresses.dummyErc721Address,
         tokenName: "Test NFT",
-        tokenId: new BigNumber("69"),
+        tokenId: BigNumber.from("69"),
         hasMetaData: false,
       },
       {
@@ -243,8 +242,8 @@ describe("Build Transfers:", () => {
         receiverEnsName: null,
         tokenAddress: testData.addresses.dummyErc1155Address,
         tokenName: "Test MultiToken",
-        amount: new BigNumber("69"),
-        tokenId: new BigNumber("420"),
+        amount: BigNumber.from("69"),
+        tokenId: BigNumber.from("420"),
         hasMetaData: false,
       },
     ];

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
-import { BigNumber } from "bignumber.js";
 import { expect } from "chai";
+import { BigNumber } from "ethers";
 
 import { fromWei, toWei, TEN, ONE, ZERO, resolveIpfsUri } from "../utils";
 
@@ -12,13 +12,13 @@ describe("toWei()", () => {
   });
   it("integers", () => {
     expect(toWei(1, 0).eq(ONE));
-    expect(toWei(123, 1).eq(new BigNumber(1230)));
-    expect(toWei(1, 18).eq(new BigNumber(1000000000000000000)));
+    expect(toWei(123, 1).eq(BigNumber.from(1230)));
+    expect(toWei(1, 18).eq(BigNumber.from(1000000000000000000)));
   });
   it("mixed", () => {
     expect(toWei(1.234, 0).eq(ONE));
-    expect(toWei(1.234, 3).eq(new BigNumber(1234)));
-    expect(toWei(1.00000000000000000001, 18).eq(new BigNumber(1000000000000000000)));
+    expect(toWei(1.234, 3).eq(BigNumber.from(1234)));
+    expect(toWei(1.00000000000000000001, 18).eq(BigNumber.from(1000000000000000000)));
   });
 });
 
@@ -31,11 +31,11 @@ describe("fromWei()", () => {
     expect(fromWei(oneETH, 19).toString()).to.be.equal("0.1");
     expect(fromWei(oneETH, 20).toString()).to.be.equal("0.01");
 
-    expect(fromWei(oneETH, 0).toFixed()).to.be.equal("1000000000000000000");
-    expect(fromWei(oneETH, 9).toFixed()).to.be.equal((10 ** 9).toString());
-    expect(fromWei(oneETH, 18).toFixed()).to.be.equal("1");
-    expect(fromWei(oneETH, 19).toFixed()).to.be.equal("0.1");
-    expect(fromWei(oneETH, 20).toFixed()).to.be.equal("0.01");
+    expect(fromWei(oneETH, 0).toString()).to.be.equal("1000000000000000000");
+    expect(fromWei(oneETH, 9).toString()).to.be.equal((10 ** 9).toString());
+    expect(fromWei(oneETH, 18).toString()).to.be.equal("1");
+    expect(fromWei(oneETH, 19).toString()).to.be.equal("0.1");
+    expect(fromWei(oneETH, 20).toString()).to.be.equal("0.01");
   });
 });
 

--- a/src/components/DrainSafeDialog.tsx
+++ b/src/components/DrainSafeDialog.tsx
@@ -1,8 +1,7 @@
 import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk";
 import { GenericModal, AddressInput, Button, Icon } from "@gnosis.pm/safe-react-components";
 import { Typography } from "@material-ui/core";
-import BigNumber from "bignumber.js";
-import { utils } from "ethers";
+import { utils, BigNumber } from "ethers";
 import { useState } from "react";
 import { AssetBalance, CollectibleBalance } from "src/hooks/balances";
 import { useEnsResolver } from "src/hooks/ens";
@@ -38,7 +37,7 @@ export const DrainSafeDialog = ({
     if (drainAddress) {
       assetBalance?.forEach((asset) => {
         if (asset.token === null && asset.tokenAddress === null) {
-          const decimalBalance = fromWei(new BigNumber(asset.balance), 18);
+          const decimalBalance = fromWei(BigNumber.from(asset.balance), 18);
           // The API returns zero balances for the native token.
           if (!decimalBalance.isZero()) {
             drainCSV += `\nnative,,${drainAddress},${decimalBalance},`;
@@ -47,7 +46,7 @@ export const DrainSafeDialog = ({
           const tokenDecimals = asset.token?.decimals;
           if (tokenDecimals) {
             drainCSV += `\nerc20,${asset.tokenAddress},${drainAddress},${fromWei(
-              new BigNumber(asset.balance),
+              BigNumber.from(asset.balance),
               tokenDecimals,
             )},`;
           }

--- a/src/components/assets/AssetTransferTable.tsx
+++ b/src/components/assets/AssetTransferTable.tsx
@@ -64,7 +64,7 @@ const Row = memo((props: RowProps) => {
         <ERC20Token tokenAddress={row.tokenAddress} symbol={row.symbol} />
         <Receiver receiverAddress={row.receiver} receiverEnsName={row.receiverEnsName} />
         <div style={{ flex: "1", padding: 16, minWidth: 80 }}>
-          <Text size="md">{row.amount?.toFixed()}</Text>
+          <Text size="md">{row.amount?.toString()}</Text>
         </div>
       </div>
     </div>

--- a/src/components/assets/CollectiblesTransferTable.tsx
+++ b/src/components/assets/CollectiblesTransferTable.tsx
@@ -80,10 +80,10 @@ export const Row = memo((props: RowProps) => {
         </div>
         <Receiver receiverAddress={row.receiver} receiverEnsName={row.receiverEnsName} />
         <div style={{ flex: "1", padding: 16, minWidth: 80 }}>
-          <Text size="md">{row.amount?.toFixed()}</Text>
+          <Text size="md">{row.amount?.toString()}</Text>
         </div>
         <div style={{ flex: "1", padding: 16, minWidth: 80 }}>
-          <Text size="md">{row.tokenId.toFixed()}</Text>
+          <Text size="md">{row.tokenId.toString()}</Text>
         </div>
       </div>
     </div>

--- a/src/components/assets/ERC721Token.tsx
+++ b/src/components/assets/ERC721Token.tsx
@@ -1,6 +1,6 @@
 import { Loader, Text } from "@gnosis.pm/safe-react-components";
 import { Popover } from "@material-ui/core";
-import { BigNumber } from "bignumber.js";
+import { BigNumber } from "ethers";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
 

--- a/src/parser/balanceCheck.ts
+++ b/src/parser/balanceCheck.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from "bignumber.js";
+import { BigNumber } from "ethers";
 
 import { AssetBalance, CollectibleBalance } from "../hooks/balances";
 import { toWei } from "../utils";
@@ -18,13 +18,13 @@ export const assetTransfersToSummary = (transfers: AssetTransfer[]) => {
     if (typeof tokenSummary === "undefined") {
       tokenSummary = {
         tokenAddress: currentValue.tokenAddress,
-        amount: new BigNumber(0),
+        amount: BigNumber.from(0),
         decimals: currentValue.decimals,
         symbol: currentValue.symbol,
       };
       previousValue.set(currentValue.tokenAddress, tokenSummary);
     }
-    tokenSummary.amount = tokenSummary.amount.plus(currentValue.amount);
+    tokenSummary.amount = tokenSummary.amount.add(currentValue.amount.toString());
 
     return previousValue;
   }, new Map<string | null, AssetSummaryEntry>());
@@ -39,7 +39,7 @@ export type CollectibleSummaryEntry = {
 
 export const collectibleTransfersToSummary = (transfers: CollectibleTransfer[]) => {
   return transfers.reduce((previousValue, currentValue): Map<string | null, CollectibleSummaryEntry> => {
-    const entryKey = `${currentValue.tokenAddress}:${currentValue.tokenId.toFixed()}`;
+    const entryKey = `${currentValue.tokenAddress}:${currentValue.tokenId.toString()}`;
     let tokenSummary = previousValue.get(entryKey);
     if (typeof tokenSummary === "undefined") {
       tokenSummary = {
@@ -89,12 +89,12 @@ export const checkAllBalances = (
 
       if (
         typeof tokenBalance === "undefined" ||
-        !isSufficientBalance(new BigNumber(tokenBalance.balance), amount, 18)
+        !isSufficientBalance(BigNumber.from(tokenBalance.balance), amount, 18)
       ) {
         insufficientTokens.push({
           token: "ETH",
           token_type: "native",
-          transferAmount: amount.toFixed(),
+          transferAmount: amount.toString(),
           isDuplicate: false, // For Erc20 / Coin Transfers duplicates are never an issue
         });
       }
@@ -104,12 +104,12 @@ export const checkAllBalances = (
       );
       if (
         typeof tokenBalance === "undefined" ||
-        !isSufficientBalance(new BigNumber(tokenBalance.balance), amount, decimals)
+        !isSufficientBalance(BigNumber.from(tokenBalance.balance), amount, decimals)
       ) {
         insufficientTokens.push({
           token: symbol || tokenAddress,
           token_type: "erc20",
-          transferAmount: amount.toFixed(),
+          transferAmount: amount.toString(),
           isDuplicate: false, // For Erc20 / Coin Transfers duplicates are never an issue
         });
       }
@@ -119,7 +119,7 @@ export const checkAllBalances = (
   for (const { tokenAddress, count, name, id } of collectibleSummary.values()) {
     const tokenBalance = collectibleBalance?.find(
       (balanceEntry) =>
-        balanceEntry.address?.toLowerCase() === tokenAddress.toLowerCase() && balanceEntry.id === id.toFixed(),
+        balanceEntry.address?.toLowerCase() === tokenAddress.toLowerCase() && balanceEntry.id === id.toString(),
     );
     if (typeof tokenBalance === "undefined" || count > 1) {
       const tokenName =

--- a/src/parser/csvParser.ts
+++ b/src/parser/csvParser.ts
@@ -1,5 +1,5 @@
 import { parseString, RowValidateCallback } from "@fast-csv/parse";
-import { BigNumber } from "bignumber.js";
+import { BigNumber, BigNumberish } from "ethers";
 
 import { CodeWarning } from "../contexts/MessageContextProvider";
 import { CollectibleTokenInfoProvider } from "../hooks/collectibleTokenInfoProvider";
@@ -21,7 +21,7 @@ export type CollectibleTokenType = "erc721" | "erc1155";
 export interface AssetTransfer {
   token_type: AssetTokenType;
   receiver: string;
-  amount: BigNumber;
+  amount: BigNumberish;
   tokenAddress: string | null;
   decimals: number;
   symbol?: string;

--- a/src/parser/transformation.ts
+++ b/src/parser/transformation.ts
@@ -1,6 +1,5 @@
 import { RowTransformCallback } from "@fast-csv/parse";
-import { BigNumber } from "bignumber.js";
-import { utils } from "ethers";
+import { utils, BigNumber } from "ethers";
 
 import { CollectibleTokenInfoProvider } from "../hooks/collectibleTokenInfoProvider";
 import { EnsResolver } from "../hooks/ens";
@@ -83,7 +82,7 @@ export const transformAsset = (
   const prePayment: PrePayment = {
     // avoids errors from getAddress. Invalid addresses are later caught in validateRow
     tokenAddress: transformERC20TokenAddress(row.token_address),
-    amount: new BigNumber(row.amount ?? row.value ?? ""),
+    amount: BigNumber.from(row.amount ?? row.value ?? ""),
     receiver: normalizeAddress(trimMatchingNetwork(row.receiver, selectedChainShortname)),
     tokenType: row.token_type,
   };
@@ -158,10 +157,10 @@ export const transformCollectible = (
   const prePayment: PreCollectibleTransfer = {
     // avoids errors from getAddress. Invalid addresses are later caught in validateRow
     tokenAddress: normalizeAddress(row.token_address),
-    tokenId: new BigNumber(row.id ?? ""),
+    tokenId: BigNumber.from(row.id ?? ""),
     receiver: normalizeAddress(row.receiver),
     tokenType: row.token_type,
-    amount: new BigNumber(row.amount ?? ""),
+    amount: BigNumber.from(row.amount ?? ""),
   };
 
   toCollectibleTransfer(prePayment, erc721InfoProvider, ensResolver)

--- a/src/parser/validation.ts
+++ b/src/parser/validation.ts
@@ -32,8 +32,9 @@ export const validateCollectibleRow = (row: CollectibleTransfer, callback: RowVa
     ...isTokenIdPositive(row),
     ...isCollectibleTokenValid(row),
     ...isTokenValueValid(row),
-    ...isTokenValueInteger(row),
-    ...isTokenIdInteger(row),
+    // Need to rethink these validations. BigNumber support for is integer.
+    // ...isTokenValueInteger(row),
+    // ...isTokenIdInteger(row),
   ];
   callback(null, warnings.length === 0, warnings.join(";"));
 };
@@ -54,7 +55,7 @@ const areAddressesValid = (row: Transfer): string[] => {
 };
 
 const isAmountPositive = (row: AssetTransfer): string[] =>
-  row.amount.isGreaterThan(0) ? [] : ["Only positive amounts/values possible: " + row.amount.toFixed()];
+  row.amount.gt(0) ? [] : ["Only positive amounts/values possible: " + row.amount.toString()];
 
 const isAssetTokenValid = (row: AssetTransfer): string[] =>
   row.decimals === -1 && row.symbol === "TOKEN_NOT_FOUND" ? [`No token contract was found at ${row.tokenAddress}`] : [];
@@ -63,17 +64,18 @@ const isCollectibleTokenValid = (row: CollectibleTransfer): string[] =>
   row.tokenName === "TOKEN_NOT_FOUND" ? [`No token contract was found at ${row.tokenAddress}`] : [];
 
 const isTokenIdPositive = (row: CollectibleTransfer): string[] =>
-  row.tokenId.isPositive() ? [] : [`Only positive Token IDs possible: ${row.tokenId.toFixed()}`];
+  row.tokenId.gt(0) ? [] : [`Only positive Token IDs possible: ${row.tokenId.toString()}`];
 
-const isTokenIdInteger = (row: CollectibleTransfer): string[] =>
-  row.tokenId.isInteger() ? [] : [`Token IDs must be integer numbers: ${row.tokenId.toFixed()}`];
+// TODO - gotta figure this part out
+// const isTokenIdInteger = (row: CollectibleTransfer): string[] =>
+//   row.tokenId.isInteger() ? [] : [`Token IDs must be integer numbers: ${row.tokenId.toString()}`];
 
-const isTokenValueInteger = (row: CollectibleTransfer): string[] =>
-  !row.amount || row.amount.isNaN() || row.amount.isInteger()
-    ? []
-    : [`Value of ERC1155 must be an integer: ${row.amount.toFixed()}`];
+// const isTokenValueInteger = (row: CollectibleTransfer): string[] =>
+//   !row.amount || row.amount.isNaN() || row.amount.isInteger()
+//     ? []
+//     : [`Value of ERC1155 must be an integer: ${row.amount.toString()}`];
 
 const isTokenValueValid = (row: CollectibleTransfer): string[] =>
-  row.token_type === "erc721" || (typeof row.amount !== "undefined" && row.amount.isGreaterThan(0))
+  row.token_type === "erc721" || (typeof row.amount !== "undefined" && row.amount.gt(0))
     ? []
-    : [`ERC1155 Tokens need a defined value > 0: ${row.amount?.toFixed()}`];
+    : [`ERC1155 Tokens need a defined value > 0: ${row.amount?.toString()}`];

--- a/src/test/safeUtil.ts
+++ b/src/test/safeUtil.ts
@@ -1,4 +1,4 @@
-import { SafeInfo } from "@gnosis.pm/safe-apps-sdk";
+import { PostMessageOptions, SafeInfo } from "@gnosis.pm/safe-apps-sdk";
 import React from "react";
 import { act } from "react-dom/test-utils";
 

--- a/src/transfers/transfers.ts
+++ b/src/transfers/transfers.ts
@@ -14,7 +14,7 @@ export function buildAssetTransfers(transferData: AssetTransfer[]): BaseTransact
       // Native asset transfer
       return {
         to: transfer.receiver,
-        value: toWei(transfer.amount, 18).toFixed(),
+        value: toWei(transfer.amount, 18).toString(),
         data: "0x",
       };
     } else {
@@ -24,7 +24,7 @@ export function buildAssetTransfers(transferData: AssetTransfer[]): BaseTransact
       return {
         to: transfer.tokenAddress,
         value: "0",
-        data: erc20Interface.encodeFunctionData("transfer", [transfer.receiver, valueData.toFixed()]),
+        data: erc20Interface.encodeFunctionData("transfer", [transfer.receiver, valueData.toString()]),
       };
     }
   });
@@ -40,7 +40,7 @@ export function buildCollectibleTransfers(transferData: CollectibleTransfer[]): 
         data: erc721Interface.encodeFunctionData("safeTransferFrom", [
           transfer.from,
           transfer.receiver,
-          transfer.tokenId.toFixed(),
+          transfer.tokenId.toString(),
         ]),
       };
     } else {
@@ -50,8 +50,8 @@ export function buildCollectibleTransfers(transferData: CollectibleTransfer[]): 
         data: erc1155Interface.encodeFunctionData("safeTransferFrom", [
           transfer.from,
           transfer.receiver,
-          transfer.tokenId.toFixed(),
-          transfer.amount?.toFixed() ?? "0",
+          transfer.tokenId.toString(),
+          transfer.amount?.toString() ?? "0",
           ethers.utils.hexlify("0x00"),
         ]),
       };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,10 @@
-import { BigNumber } from "bignumber.js";
+import { ethers, BigNumber } from "ethers";
 
-export const ZERO = new BigNumber(0);
-export const ONE = new BigNumber(1);
-export const TWO = new BigNumber(2);
-export const TEN = new BigNumber(10);
-export const MAX_U256 = TWO.pow(255).minus(1);
+export const ZERO = BigNumber.from(0);
+export const ONE = BigNumber.from(1);
+export const TWO = BigNumber.from(2);
+export const TEN = BigNumber.from(10);
+export const MAX_U256 = TWO.pow(255).sub(1);
 
 export const DONATION_ADDRESS = "0xD011a7e124181336ED417B737A495745F150d248";
 
@@ -22,25 +22,11 @@ export interface TokenInfo {
 }
 
 export function toWei(amount: string | number | BigNumber, decimals: number): BigNumber {
-  // # TODO - replace all this logic with ethers.utils.formatUnits
-  let res = TEN.pow(decimals).multipliedBy(amount);
-  const decimalPlaces = res.decimalPlaces();
-  // unsure when this can be null, so we simply skip the case as a possibility.
-  if (decimalPlaces != null && decimalPlaces > 0) {
-    // TODO - reinstate this warning by passing along with return content
-    // Return (Transaction[], Message)
-    // setLastError({
-    //   message:
-    //     "Precision too high. Some digits are ignored for row " + index,
-    // });
-    res = res.decimalPlaces(0, BigNumber.ROUND_DOWN);
-  }
-  return res;
+  return ethers.utils.parseUnits(amount.toString(), decimals);
 }
 
 export function fromWei(amount: BigNumber, decimals: number): BigNumber {
-  // # TODO - replace all this logic with ethers.utils.parseUnits
-  return amount.dividedBy(TEN.pow(decimals));
+  return BigNumber.from(ethers.utils.formatUnits(amount, decimals));
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -3648,11 +3648,6 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
-bignumber.js@^9.0.2:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.0.tgz#8d340146107fe3a6cb8d40699643c302e8773b62"
-  integrity sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==
-
 binary-extensions@^1.0.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"


### PR DESCRIPTION
Intended to close #458, but its going to be a while.

Most of this involves using ethers.BigNumber instead of bignumberjs.BigNumber but the differences are causing difficulties.

Goal is to remove our hand written "toWEI" and "fromWEI" functions.