### PR TITLE
fix: donations with value column

### DIFF
--- a/src/components/DonateDialog.tsx
+++ b/src/components/DonateDialog.tsx
@@ -1,5 +1,5 @@
 import { useSafeAppsSDK } from "@gnosis.pm/safe-apps-react-sdk";
-import { GenericModal, Button, Select, TextFieldInput, Icon } from "@gnosis.pm/safe-react-components";
+import { Button, GenericModal, Icon, Select, TextFieldInput } from "@gnosis.pm/safe-react-components";
 import { InputAdornment, Typography } from "@material-ui/core";
 import { BigNumber, ethers } from "ethers";
 import { useEffect, useState } from "react";
@@ -72,6 +72,7 @@ export const DonateDialog = ({
         .replace("token_address", selectedToken === "0x0" ? "" : selectedToken)
         .replace("receiver", DONATION_ADDRESS)
         .replace("amount", selectedAmount)
+        .replace("value", selectedAmount)
         .replace("id", "");
 
       onSubmit(`${csvText}\n${donationCSVRow}`);

--- a/src/components/FAQModal.tsx
+++ b/src/components/FAQModal.tsx
@@ -1,4 +1,4 @@
-import { Icon, Text, Title, Divider, Button, GenericModal, Link } from "@gnosis.pm/safe-react-components";
+import { Button, Divider, GenericModal, Icon, Link, Text, Title } from "@gnosis.pm/safe-react-components";
 import { Fab } from "@material-ui/core";
 import { useState } from "react";
 
@@ -98,7 +98,7 @@ export const FAQModal: () => JSX.Element = () => {
               </Title>
               <Text size="lg">
                 As the BEP-20 standard is an extension of ERC20 they are supported by this app. Just pass{" "}
-                <code>erc20</code> as <code>token_id</code>.
+                <code>erc20</code> as <code>token_type</code>.
               </Text>
               <Divider />
               <Title size="md" strong>


### PR DESCRIPTION
Users can name the amount column `value` for compatibility reasons. 

The donation should also work if users do this.