### PR TITLE
fix: remove word from label

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,7 +127,7 @@ const App: React.FC = () => {
                       >
                         {parsing && (
                           <>
-                            <CircularProgress size={24} color="primary" /> Parsing
+                            <CircularProgress size={24} color="primary" />
                           </>
                         )}
                         {messages.length === 0 ? "Submit" : "Submit with errors"}


### PR DESCRIPTION
I accidentally left the word "Parsing" on the button but I intended to remove it.

This fixes the button label during parsing.