### PR TITLE
fix: Adjust button color and order

### DIFF
--- a/src/components/DonateDialog.tsx
+++ b/src/components/DonateDialog.tsx
@@ -153,16 +153,17 @@ export const DonateDialog = ({
           />
         </Box>
       </DialogContent>
-      <DialogActions>
-        <div style={{ display: "flex", justifyContent: "space-between" }}>
+      <DialogActions sx={{ padding: "0 24px 24px" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: "8px" }}>
+          <Button color="primary" onClick={onClose}>
+            Abort
+          </Button>
           <Button
+            variant="contained"
             onClick={handleSubmit}
-            disabled={Boolean(amountError) || !Boolean(selectedToken) || !Boolean(selectedAmount)}
+            disabled={Boolean(amountError) || !Boolean(selectedToken) || !Boolean(Number(selectedAmount))}
           >
             Add to CSV
-          </Button>
-          <Button color="secondary" onClick={onClose}>
-            Abort
           </Button>
         </div>
       </DialogActions>

--- a/src/components/DrainSafeDialog.tsx
+++ b/src/components/DrainSafeDialog.tsx
@@ -108,7 +108,7 @@ export const DrainSafeDialog = ({
     <Dialog onClose={onClose} open sx={{ padding: 3 }}>
       <DialogTitle>Transfer all funds</DialogTitle>
       <DialogContent>
-        <Box sx={{ padding: 3 }}>
+        <Box>
           <Typography style={{ marginBottom: "16px" }}>
             Select an address to transfer all funds to. These funds include all ERC20, ERC721 and native tokens.
           </Typography>
@@ -138,10 +138,14 @@ export const DrainSafeDialog = ({
           />
         </Box>
       </DialogContent>
-      <DialogActions>
-        <div style={{ display: "flex", justifyContent: "space-between" }}>
+      <DialogActions sx={{ padding: "0 24px 24px" }}>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: "8px" }}>
+          <Button color="primary" onClick={onClose}>
+            Abort
+          </Button>
           <Button
             disabled={!!error || drainAddress === ""}
+            variant="contained"
             color="primary"
             onClick={() => {
               generateDrainTransfers();
@@ -149,9 +153,6 @@ export const DrainSafeDialog = ({
             }}
           >
             Submit
-          </Button>
-          <Button color="secondary" onClick={onClose}>
-            Abort
           </Button>
         </div>
       </DialogActions>

--- a/src/components/FAQModal.tsx
+++ b/src/components/FAQModal.tsx
@@ -106,8 +106,8 @@ export const FAQModal: () => JSX.Element = () => {
             </Typography>
           </Box>
         </DialogContent>
-        <DialogActions>
-          <Button color="secondary" onClick={() => setShowHelp(false)}>
+        <DialogActions sx={{ padding: "24px" }}>
+          <Button variant="contained" color="primary" onClick={() => setShowHelp(false)}>
             Close
           </Button>
         </DialogActions>


### PR DESCRIPTION
## What it solves

The green button color is hard to read against a white background and the order of the buttons suggests that "Abort" is the primary action.

- Moves the primary action button to the right
- Changes the color of the secondary action button
- Adjusts Dialog spacings to be more consistent

Before:
<img width="619" alt="Screenshot 2023-06-29 at 16 38 02" src="https://github.com/bh2smith/safe-airdrop/assets/5880855/115b4e29-a34a-4d7a-accf-418d0928571f">

After:
<img width="626" alt="Screenshot 2023-06-29 at 16 41 23" src="https://github.com/bh2smith/safe-airdrop/assets/5880855/b658582f-82b8-4301-926f-3abdc91db195">

