### PR TITLE
Revert "chore(deps): bump tslib from 2.5.0 to 2.6.1 (#533)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-svg": "^16.1.10",
     "react-virtualized-auto-sizer": "^1.0.6",
     "react-window": "^1.8.9",
-    "tslib": "^2.6.1",
+    "tslib": "^2.5.0",
     "typescript": "~5.0.4"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10862,10 +10862,10 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
-  integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
+tslib@^2.0.3, tslib@^2.4.0, tslib@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
This reverts commit e3acaaeef3f1d952e3f7b22664e3a61b2c33fd42.