### PR TITLE
Attempt Node Version Bump

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [16.x]
+        node: [16.x, 20.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Adding node v20.x to CI matrix. We can observe that CI still passes under node version 20. I went to update the build command, but it doesn't appear to specify a node version. Not sure if I am missing something here, but it appears we can start building with more recent node version.