### PR TITLE
Migrated Gateway Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@emotion/react": "^11.11.1",
     "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.11.0",
-    "@gnosis.pm/safe-react-gateway-sdk": "^3.5.2",
     "@mui/icons-material": "^5.14.11",
     "@mui/material": "^5.14.11",
     "@mui/styles": "^5.14.4",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@safe-global/safe-apps-provider": "^0.18.0",
     "@safe-global/safe-apps-react-sdk": "^4.6.4",
     "@safe-global/safe-apps-sdk": "^8.1.0",
+    "@safe-global/safe-gateway-typescript-sdk": "^3.13.2",
     "@safe-global/safe-react-components": "2.0.5",
     "ace-builds": "^1.15.0",
     "bignumber.js": "^9.1.1",

--- a/src/hooks/token.ts
+++ b/src/hooks/token.ts
@@ -1,6 +1,6 @@
-import { SafeBalanceResponse } from "@gnosis.pm/safe-react-gateway-sdk";
 import { SafeAppProvider } from "@safe-global/safe-apps-provider";
 import { useSafeAppsSDK } from "@safe-global/safe-apps-react-sdk";
+import { SafeBalanceResponse } from "@safe-global/safe-gateway-typescript-sdk";
 import { ethers, utils } from "ethers";
 import xdaiTokens from "honeyswap-default-token-list";
 import { useState, useEffect, useMemo } from "react";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,6 @@
     "noUnusedLocals": false,
     "skipLibCheck": true,
     "strictNullChecks": true,
-    "suppressImplicitAnyIndexErrors": true,
     "types": ["jest", "node"],
     "baseUrl": ".",
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2750,6 +2750,11 @@
     "@safe-global/safe-gateway-typescript-sdk" "^3.5.3"
     viem "^1.0.0"
 
+"@safe-global/safe-gateway-typescript-sdk@^3.13.2":
+  version "3.13.2"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.13.2.tgz#f03884c7eb766f5508085d95ab96063a28e20920"
+  integrity sha512-kGlJecJHBzGrGTq/yhLANh56t+Zur6Ubpt+/w03ARX1poDb4TM8vKU3iV8tuYpk359PPWp+Qvjnqb9oW2YQcYw==
+
 "@safe-global/safe-gateway-typescript-sdk@^3.5.3":
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/@safe-global/safe-gateway-typescript-sdk/-/safe-gateway-typescript-sdk-3.7.0.tgz#2af52f1bc73759b1b6a549fed598781c8c5fce72"


### PR DESCRIPTION
In response to deprecation notice

https://www.npmjs.com/package/@gnosis.pm/safe-react-gateway-sdk

Also removed a deprecated TS config.