### PR TITLE
Add Sepolia as Supported Network

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-airdrop",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/src/networks.ts
+++ b/src/networks.ts
@@ -139,4 +139,14 @@ export const networkInfo = new Map<number, NetworkInfo>([
       baseAPI: "https://safe-transaction-volta.safe.global/api/v1",
     },
   ],
+  [
+    11155111,
+    {
+      chainID: 11155111,
+      name: "Sepolia",
+      shortName: "sep",
+      currencySymbol: "ETH",
+      baseAPI: "https://safe-transaction-sepolia.safe.global/api/v1",
+    },
+  ],
 ]);


### PR DESCRIPTION
I believe this needs to go along with that: https://github.com/safe-global/safe-ecosystem-database/pull/85

Maybe also a redeployment to IPFS (although I can't find the place the the hash goes).

It appears the IPFS deployment process has changed. I ran

```
yarn build
ipfs init
ipfs add -r build
```

which recursively gave hashes for the entire directory:

<details><summary> See here</summary>

```
added QmUBp2ct9WxQqxkQx2NcpKtuZH65r59cUuyqCQAx5qw3ve build/asset-manifest.json
added QmPVRUkiR9zzs577irgKPU28p9m3YsakaQ8PGXNbtjgWJ4 build/favicon.ico
added QmdrLaM3owves5W91V7x3bg5jpS6oHxNataAFnJpCPhLG5 build/index.html
added QmcKLD9P4TokvtrE47VTidaFb7K9edmorzFsmgKZzkth8V build/logo.svg
added QmZe6EGQtCv2gd5KjmpaAGWnHcyVRmHz4cG8mXKPDk7oJ3 build/manifest.json
added QmZxX6rtNN7VJnuPS8ir4EctYbQ3vk7XrqQWSnnQzwY7Wt build/robots.txt
added QmeuhawiUeE1gLECnCTRu9kuCeAcgnR1XFMFBwasotpvrv build/sample.csv
added QmbcJh8cRQ1vuo1HVFDKT2wK548LkoofZe7Urn4n2pyHkN build/static/css/main.0e99ede7.css
added QmWAdFw5pooq5kcvspoa8bH6GC2sQQT5yyBQdjViDFnMBA build/static/css/main.0e99ede7.css.map
added QmcKpnTeRHEscnjJLTLEEDAdVR1kchn3FmnzGHxFyQvY4c build/static/js/main.5b830939.js
added QmXujf2MsiqHKTeVmHLBAhwMnk1qu35JoRxVxxQpMZbtiW build/static/js/main.5b830939.js.LICENSE.txt
added QmYdkiUtXfUy57rJuhkWg6N49ri5NAReqCmCJzyDgKCFfm build/static/js/main.5b830939.js.map
added Qmb5VcqvVfYFkLT3DMTYmDPXW6W9w3Ez5Yua2czBVEEbqD build/static/media/DMSans700.d5ac740f6f0cf65a6193.woff2
added QmWPcF9xmzy6SRY9pyv5Aj3q9M33cMyPg2QgEmk8618gox build/static/media/DMSansRegular.99b8e0b20a45ca4d73bf.woff2
added QmaaYVZ5D7tdpthpBUvrDEqiRn5AEqfHXNQGpssrQJjVGz build/static/media/assets-light.6df1a597cf64f715229a6af430c448ed.svg
added QmQ9MPR9YqjcajRDZcgedjdYWoHZdXVY4zpAjmna2CgDZC build/static/media/assets.e6f4abcc8aa3d716a0d0bd49bd8bcd6a.svg
added QmW4aangDcMwED2k55eTpUQEueJYYheRKAhW2gUUYMuWxU build/static/media/check.c5f7857c2def287b4ac78299d9860eae.svg
added QmNwwYNJ9vGpH6Gwisj35fndRqAZUxWrneaernJT8P4EQ5 build/static/media/error-icon.30ff2119f3f188798277.svg
added QmNwwYNJ9vGpH6Gwisj35fndRqAZUxWrneaernJT8P4EQ5 build/static/media/error-icon.30ff2119f3f1887982778f068889486c.svg
added QmZk6sNGbXfjNgnG1zzSqWkHDaCnHHhi4icxFFCBfsgrmB build/static/media/logo.8d621a0e55f824df588f83f9a58dd76d.svg
added QmWKrvDMcA8cGJvkf77ftYb4ESbo5E6LNAevppTyJE6zQc build/static/media/nft-light.1392cc25f495fa9be97658793e2be87e.svg
added QmQGzqvized6ZBjcCzUPwvmaPJEZcNJBDiV8HXTCnXY8DE build/static/media/nft.661fa48a2b2800aa0bb46d91fa71d969.svg
added QmPWE2cBi7F3gPHrQbnH9aJ2xTCxQF9Pa5ZePUh49Uur7A build/tutorial/App-screen.png
added QmczjRWXRVPLeXxwS7zYqdRePRVgqDtU8q7MJX4m6PWwiH build/tutorial/File-uploaded.png
added QmV8bNQZJModW7eDT3mD9vwXfLARghNEs7AKAzZtxD42dE build/tutorial/Transaction-submission.png
added QmVexRQeZZASeuhpH2twqCEH9Qos3z5UYzu9udu7RfuVwx build/tutorial/tx-success.png
added QmXNM4rNiwnodPKQCBEin3QTvoRMeLUd7rLJKurM5Y8GXj build/static/css
added QmWjVvGR7onicsxm26BLLbxqM5ruvLzUhcC2kRPQWv2GaX build/static/js
added QmRbj6qLLswqfSzRNoEGhNJq4EDoh4vZ7e1YLgcuGHfzAU build/static/media
added QmcuihBeKQEyqkSJgwWx3ZeafEtSt8cejWwFdBnNQzTcSS build/static
added QmTrEjp9Qh6GRH9Vdyhr8JiUmjwnDR61ijwph9iVC3G3kF build/tutorial
added QmPHPpqaZUCNnw4ySmKneybepiRcvnSPZLfDjVQQuoB5AR build
```

</details>

followed by `ipfs pin add QmPHPpqaZUCNnw4ySmKneybepiRcvnSPZLfDjVQQuoB5AR` (the build hash). However, it does not appear to be "the app"...