### PR TITLE
feat: config service as param

### DIFF
--- a/src/hooks/useChains.ts
+++ b/src/hooks/useChains.ts
@@ -37,9 +37,21 @@ export const useLoadChains = () => {
   }, [chains, dispatch]);
 };
 
+const useConfigService = () => {
+  const configUrl = useMemo(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const configParam = urlParams.get("configUrl");
+    return configParam || CONFIG_SERVICE_URL;
+  }, []);
+
+  return configUrl;
+};
+
 const useChains = () => {
+  const configUrl = useConfigService();
+
   const { data: chainConfigs, isLoading } = useSwr("chains", async (): Promise<NetworkInfo[]> => {
-    const result = await fetch(CONFIG_SERVICE_URL).then((resp) => {
+    const result = await fetch(configUrl).then((resp) => {
       if (resp.ok) {
         return resp.json() as Promise<ChainEndpointResponse>;
       }


### PR DESCRIPTION
Resolves #627

What this PR changes:

- Looks for the configUrl parameter in the query string to use it as a custom ConfigService URL.
- Uses the hardcoded ConfigService URL as a fallback if the parameter is not present.