### PR TITLE
Upgrade CI Actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,13 +13,13 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
       - id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ matrix.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,17 +14,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
-      - id: yarn-cache
-        run: echo "DIR=$(yarn cache dir)" >> "$GITHUB_ENV"
-      - uses: actions/cache@v4
+          node-version: "20"
+
+      - name: Cache node modules
+        uses: actions/cache@v4
         with:
-          path: ${{ env.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: |
+            node_modules
+            ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
       - run: yarn --frozen-lockfile
       - run: yarn build
       - run: yarn lint

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,13 +18,13 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "DIR=$(yarn cache dir)" >> "$GITHUB_ENV"
       - uses: actions/cache@v4
         with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ matrix.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          path: ${{ env.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ matrix.os }}-yarn-
+            ${{ runner.os }}-yarn-
       - run: yarn --frozen-lockfile
       - run: yarn build
       - run: yarn lint


### PR DESCRIPTION
Our CI file was giving lots of warnings about outdated use of github actions. This aims to upgrade to the latest. 

Before: https://github.com/bh2smith/safe-airdrop/actions/runs/13201903558

After: https://github.com/bh2smith/safe-airdrop/actions/runs/13201993342